### PR TITLE
Use context manager to open file for robust close

### DIFF
--- a/examples/pdb_dump.py
+++ b/examples/pdb_dump.py
@@ -12,6 +12,5 @@ else:
     
 for stream in streams:
     ofname = basename(pdb.fp.name) + ('.%03d' % stream.index)
-    f = open(ofname, 'w')
-    f.write(stream.data)
-    f.close()
+    with open(ofname, 'w') as f:
+        f.write(stream.data)


### PR DESCRIPTION
This is typically safer than an open() and a close()