### PR TITLE
[setup] Future proofing construct dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ setup(name='pdbparse',
       author_email='brendandg@gatech.edu',
       url='http://pdbparse.googlecode.com/',
       packages=['pdbparse'],
-      requires=['construct', 'pefile'],
+      install_requires = [
+        'construct<=2.5.2', # last known release from https://github.com/tomerfiliba
+        'pefile'
+      ],
       classifiers=[
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Operating System :: OS Independent',


### PR DESCRIPTION
While porting `pdbparse` to Python3, I've noticed a bunch of `construct` errors (`ULInt32 not being defined` for example). The reason being that, after several years of sleep, [the construct2 project](https://github.com/construct/construct) is active again. 

However they introduced breaking changes in the API around v2.8 ([see this issue for example](https://github.com/construct/construct/issues/271)). Honestly this is kind of infuriating ( _who break a 5 y.o library without at least changing the major version ?_ ) and I don't want to update all the `construct` structs in `pdbparse` until I'm positive the construct guys won't break again the API.

To stay on the safe side, I stopped the dependency requirement to the last version released by tomer filiba, the original author of construct.

L.

PS: as a side note, if I were you I would drop the `undname` C module in `pdbparse` which greatly encumber the whole building process while providing little added value and release the next version of `pdbparse` as a Pure-python library  (no separate Linux/Windows build toolchain requirements anymore).