### PR TITLE
Add support for Python3 compilation of undname C module.

### DIFF
--- a/src/undname.h
+++ b/src/undname.h
@@ -1,0 +1,6 @@
+#ifndef UNDNAME_H
+#define UNDNAME_H
+
+char *undname(char *buffer, char *mangled, int buflen, unsigned short int flags);
+
+#endif

--- a/src/undname_py.c
+++ b/src/undname_py.c
@@ -1,0 +1,67 @@
+#include "undname.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <ctype.h>
+
+// Should work as is on Python 2.7
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K
+
+#include "Python.h"
+#include "bytesobject.h"
+
+
+static PyObject* undname_py(PyObject* self,PyObject* args)
+{
+    Py_buffer buffer;
+    Py_buffer mangled;
+    PyObject *return_value;
+
+    int buflen;
+    unsigned short int flags;
+    char *out;
+
+    if (!PyArg_ParseTuple(args, "s*s*iH", &buffer, &mangled, &buflen, &flags));
+        return NULL;
+
+    Py_INCREF(buffer);
+    Py_INCREF(mangled);
+    out = undname(buffer->buf, mangled->buf, buflen, flags);
+    if (!out)
+        return NULL;
+    Py_DECREF(buffer);
+    Py_DECREF(mangled);
+
+    return_value = Py_BuildValue("s",out);
+    Py_INCREF(return_value);
+
+    // Discaring temporary unmangled buffer
+    free(out);
+
+    return return_value;
+}
+
+static PyMethodDef undname_methods[] = {
+    {"undname", (PyCFunction)undname_py, METH_VARARGS, "Undecorate mangled C++ names"},
+    {NULL, NULL}
+};
+
+
+static struct PyModuleDef cUndnameModule =
+{
+    PyModuleDef_HEAD_INIT,
+    "undname",   /* name of module */
+    "",          /* module documentation, may be NULL */
+    -1,          /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+    undname_methods
+};
+
+PyMODINIT_FUNC PyInit_undname(void)
+{
+    return PyModule_Create(&cUndnameModule);
+}
+
+#endif


### PR DESCRIPTION
Since Python3, it is mandatory to define a `PyInit_${module_name}` entry
point function or a `PyModuleDef` structure (see doc on this subject :
https://docs.python.org/3/extending/building.html).

This commit add support for building the undname C module on Python 3 as
well as Python27. It somewhat slipped away from the previous Python3 pull
request.

NB : I've used [this tutorial](http://adamlamers.com/post/NUBSPFQJ50J1) to write the Python glue.