### PR TITLE
Add support for undname extension on Windows

### DIFF
--- a/pdbparse/undname.py
+++ b/pdbparse/undname.py
@@ -1,10 +1,6 @@
 import os
-import ctypes
+from . import _undname # automatically resolve and load shared library (_undame.pyd or _undame.so)
 
-_undname = ctypes.CDLL(os.path.join(os.path.dirname(__file__), '_undname.so'))
-
-_undname.undname.restype = ctypes.c_char_p
-BUFSZ = 2048
 
 UNDNAME_COMPLETE                 = 0x0000
 UNDNAME_NO_LEADING_UNDERSCORES   = 0x0001 # Don't show __ in calling convention
@@ -26,8 +22,9 @@ UNDNAME_NO_SPECIAL_SYMS          = 0x4000
 UNDNAME_NO_COMPLEX_TYPE          = 0x8000
 
 def undname(name, flags=UNDNAME_NAME_ONLY):
+  
     if name.startswith("?"):
-        name = _undname.undname(ctypes.create_string_buffer(BUFSZ), name, BUFSZ, flags)
+        name = _undname.undname(name, flags)
     elif name.startswith("_") or name.startswith("@"):
         name = name.rsplit('@',1)[0][1:]
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pdbparse',
         'Operating System :: OS Independent',
       ],
       ext_modules=[
-        Extension('pdbparse._undname', ['src/undname.c'], export_symbols=['undname'])
+        Extension('pdbparse._undname', sources = ['src/undname.c', 'src/undname_py.c'])
       ],
       scripts=[
         'examples/pdb_dump.py',

--- a/src/undname.h
+++ b/src/undname.h
@@ -1,6 +1,17 @@
 #ifndef UNDNAME_H
 #define UNDNAME_H
 
+#include "Python.h"
+
+// wine C undname function
 char *undname(char *buffer, char *mangled, int buflen, unsigned short int flags);
+
+#ifdef PY3K
+// Python module "_undname" entry point for Python3
+PyMODINIT_FUNC PyInit__undname(void);
+#else
+// Python module "_undname" entry point for Python2
+PyMODINIT_FUNC init_undname(void);
+#endif
 
 #endif

--- a/src/undname_py.c
+++ b/src/undname_py.c
@@ -6,62 +6,66 @@
 #include <string.h>
 #include <ctype.h>
 
-// Should work as is on Python 2.7
 #if PY_MAJOR_VERSION >= 3
-#define IS_PY3K
+#define PY3K
+#endif
 
-#include "Python.h"
-#include "bytesobject.h"
-
+static const char undname_doc[] = ""                                  \
+"undname(mangled: str or bytes,flags : int) -> str \n\n"              \
+"Undecorate mangled C++ names. Take a mangled str name and flags.\n"  \
+"Return the unmangled name or None if it can not be undecorated.";
 
 static PyObject* undname_py(PyObject* self,PyObject* args)
 {
-    Py_buffer buffer;
     Py_buffer mangled;
     PyObject *return_value;
 
-    int buflen;
-    unsigned short int flags;
+    unsigned short int flags = 0;
     char *out;
 
-    if (!PyArg_ParseTuple(args, "s*s*iH", &buffer, &mangled, &buflen, &flags));
-        return NULL;
-
-    Py_INCREF(buffer);
-    Py_INCREF(mangled);
-    out = undname(buffer->buf, mangled->buf, buflen, flags);
+    if (!PyArg_ParseTuple(args, "s*H:undname", &mangled, &flags))
+        return Py_None;
+        
+    // passing NULL as buffer : dynamic allocation used
+    out = undname(NULL, (char*) mangled.buf, (int) mangled.len, flags);
     if (!out)
-        return NULL;
-    Py_DECREF(buffer);
-    Py_DECREF(mangled);
+        return Py_None;
+
 
     return_value = Py_BuildValue("s",out);
     Py_INCREF(return_value);
 
-    // Discaring temporary unmangled buffer
+    // Discaring temporary unmangled bufferhelp
     free(out);
 
     return return_value;
 }
 
 static PyMethodDef undname_methods[] = {
-    {"undname", (PyCFunction)undname_py, METH_VARARGS, "Undecorate mangled C++ names"},
-    {NULL, NULL}
+    {"undname", undname_py, METH_VARARGS, undname_doc},
+    {NULL, NULL, 0, NULL}
 };
 
 
+
+#ifdef PY3K
+// module definition structure for python3
 static struct PyModuleDef cUndnameModule =
 {
     PyModuleDef_HEAD_INIT,
-    "undname",   /* name of module */
-    "",          /* module documentation, may be NULL */
+    "_undname",   /* name of module */
+    "_undname module. Provide undname() function for symbol undecoration",       /* module documentation, may be NULL */
     -1,          /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
     undname_methods
 };
 
-PyMODINIT_FUNC PyInit_undname(void)
+PyMODINIT_FUNC PyInit__undname(void)
 {
     return PyModule_Create(&cUndnameModule);
 }
-
+#else
+// module initializer for python2
+PyMODINIT_FUNC init_undname(void) {
+    Py_InitModule3("_undname", undname_methods, "_undname module. Provide undname() function for symbol undecoration");
+}
 #endif


### PR DESCRIPTION
Since it was bothering me I've completed to port the `_undname` C extension on Windows. Previously `_undname` was just a shared library loaded via `ctypes`, now it's a full fledged Python extension à la `_hashlib`, `_socket` or `_sqlite3`.

It works like any Python module :

```
(lin_env_3) lucasg@DESKTOP-822EGME:/mnt/f/Dev$ python
Python 3.4.3 (default, Nov 17 2016, 01:08:31)
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pdbparse import undname
>>> print(undname._undname.__doc__)
_undname module. Provide undname() function for symbol undecoration
>>> dir(undname._undname)
['__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', 'undname']
>>> print(undname._undname.undname.__doc__)
undname(mangled: str or bytes,flags : int) -> str

Undecorate mangled C++ names. Take a mangled str name and flags.
Return the unmangled name or None if it can not be undecorated.
>>> undname.undname("?Request@MUTEX@@QEAAXXZ")
'MUTEX::Request'
>>> undname._undname.undname(b"?Request@MUTEX@@QEAAXXZ", 0x00)
'public: void __cdecl MUTEX::Request(void) __ptr64'
```