### PR TITLE
Updating to support Construct-2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Created by .ignore support plugin (hsz.mobi)
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Created by .ignore support plugin (hsz.mobi)
 
 .idea
+__pycache__

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,261 @@
+[style]
+# Align closing bracket with visual indentation.
+align_closing_bracket_with_visual_indent=True
+
+# Allow dictionary keys to exist on multiple lines. For example:
+#
+#   x = {
+#       ('this is the first element of a tuple',
+#        'this is the second element of a tuple'):
+#            value,
+#   }
+allow_multiline_dictionary_keys=False
+
+# Allow lambdas to be formatted on more than one line.
+allow_multiline_lambdas=False
+
+# Allow splits before the dictionary value.
+allow_split_before_dict_value=True
+
+# Number of blank lines surrounding top-level function and class
+# definitions.
+blank_lines_around_top_level_definition=2
+
+# Insert a blank line before a class-level docstring.
+blank_line_before_class_docstring=False
+
+# Insert a blank line before a module docstring.
+blank_line_before_module_docstring=False
+
+# Insert a blank line before a 'def' or 'class' immediately nested
+# within another 'def' or 'class'. For example:
+#
+#   class Foo:
+#                      # <------ this blank line
+#     def method():
+#       ...
+blank_line_before_nested_class_or_def=True
+
+# Do not split consecutive brackets. Only relevant when
+# dedent_closing_brackets is set. For example:
+#
+#    call_func_that_takes_a_dict(
+#        {
+#            'key1': 'value1',
+#            'key2': 'value2',
+#        }
+#    )
+#
+# would reformat to:
+#
+#    call_func_that_takes_a_dict({
+#        'key1': 'value1',
+#        'key2': 'value2',
+#    })
+coalesce_brackets=False
+
+# The column limit.
+column_limit=120
+
+# The style for continuation alignment. Possible values are:
+#
+# - SPACE: Use spaces for continuation alignment. This is default behavior.
+# - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
+#   (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs) for continuation
+#   alignment.
+# - LESS: Slightly left if cannot vertically align continuation lines with
+#   indent characters.
+# - VALIGN-RIGHT: Vertically align continuation lines with indent
+#   characters. Slightly right (one more indent character) if cannot
+#   vertically align continuation lines with indent characters.
+#
+# For options FIXED, and VALIGN-RIGHT are only available when USE_TABS is
+# enabled.
+continuation_align_style=SPACE
+
+# Indent width used for line continuations.
+continuation_indent_width=4
+
+# Put closing brackets on a separate line, dedented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#   }        # <--- this bracket is dedented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#   )        # <--- this bracket is dedented and on a separate line
+dedent_closing_brackets=False
+
+# Disable the heuristic which places each list element on a separate line
+# if the list is comma-terminated.
+disable_ending_comma_heuristic=False
+
+# Place each dictionary entry onto its own line.
+each_dict_entry_on_separate_line=True
+
+# The regex for an i18n comment. The presence of this comment stops
+# reformatting of that line, because the comments are required to be
+# next to the string they translate.
+i18n_comment=
+
+# The i18n function call names. The presence of this function stops
+# reformattting on that line, because the string it has cannot be moved
+# away from the i18n comment.
+i18n_function_call=
+
+# Indent the dictionary value if it cannot fit on the same line as the
+# dictionary key. For example:
+#
+#   config = {
+#       'key1':
+#           'value1',
+#       'key2': value1 +
+#               value2,
+#   }
+indent_dictionary_value=False
+
+# The number of columns to use for indentation.
+indent_width=4
+
+# Join short lines into one line. E.g., single line 'if' statements.
+join_multiple_lines=True
+
+# Do not include spaces around selected binary operators. For example:
+#
+#   1 + 2 * 3 - 4 / 5
+#
+# will be formatted as follows when configured with "*,/":
+#
+#   1 + 2*3 - 4/5
+#
+no_spaces_around_selected_binary_operators=
+
+# Use spaces around default or named assigns.
+spaces_around_default_or_named_assign=True
+
+# Use spaces around the power operator.
+spaces_around_power_operator=True
+
+# The number of spaces required before a trailing comment.
+spaces_before_comment=2
+
+# Insert a space between the ending comma and closing bracket of a list,
+# etc.
+space_between_ending_comma_and_closing_bracket=True
+
+# Split before arguments
+split_all_comma_separated_values=False
+
+# Split before arguments if the argument list is terminated by a
+# comma.
+split_arguments_when_comma_terminated=False
+
+# Set to True to prefer splitting before '&', '|' or '^' rather than
+# after.
+split_before_bitwise_operator=True
+
+# Split before the closing bracket if a list or dict literal doesn't fit on
+# a single line.
+split_before_closing_bracket=True
+
+# Split before a dictionary or set generator (comp_for). For example, note
+# the split before the 'for':
+#
+#   foo = {
+#       variable: 'Hello world, have a nice day!'
+#       for variable in bar if variable != 42
+#   }
+split_before_dict_set_generator=True
+
+# Split before the '.' if we need to split a longer expression:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'.format(a, b, c, d))
+#
+# would reformat to something like:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'
+#          .format(a, b, c, d))
+split_before_dot=False
+
+# Split after the opening paren which surrounds an expression if it doesn't
+# fit on a single line.
+split_before_expression_after_opening_paren=False
+
+# If an argument / parameter list is going to be split, then split before
+# the first argument.
+split_before_first_argument=False
+
+# Set to True to prefer splitting before 'and' or 'or' rather than
+# after.
+split_before_logical_operator=True
+
+# Split named assignments onto individual lines.
+split_before_named_assigns=True
+
+# Set to True to split list comprehensions and generators that have
+# non-trivial expressions and multiple clauses before each of these
+# clauses. For example:
+#
+#   result = [
+#       a_long_var + 100 for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+#
+# would reformat to something like:
+#
+#   result = [
+#       a_long_var + 100
+#       for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+split_complex_comprehension=True
+
+# The penalty for splitting right after the opening bracket.
+split_penalty_after_opening_bracket=200
+
+# The penalty for splitting the line after a unary operator.
+split_penalty_after_unary_operator=10000
+
+# The penalty for splitting right before an if expression.
+split_penalty_before_if_expr=0
+
+# The penalty of splitting the line around the '&', '|', and '^'
+# operators.
+split_penalty_bitwise_operator=300
+
+# The penalty for splitting a list comprehension or generator
+# expression.
+split_penalty_comprehension=80
+
+# The penalty for characters over the column limit.
+split_penalty_excess_character=7000
+
+# The penalty incurred by adding a line split to the unwrapped line. The
+# more line splits added the higher the penalty.
+split_penalty_for_added_line_split=30
+
+# The penalty of splitting a list of "import as" names. For example:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (long_argument_1,
+#                                                             long_argument_2,
+#                                                             long_argument_3)
+#
+# would reformat to something like:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (
+#       long_argument_1, long_argument_2, long_argument_3)
+split_penalty_import_names=0
+
+# The penalty of splitting the line around the 'and' and 'or'
+# operators.
+split_penalty_logical_operator=300
+
+# Use the Tab character for indentation.
+use_tabs=False
+

--- a/examples/pdb_dump.py
+++ b/examples/pdb_dump.py
@@ -4,17 +4,19 @@ from os.path import basename
 import pdbparse
 import sys
 
+
 def main(pdbfilepath):
-	pdb = pdbparse.parse(pdbfilepath, fast_load=True)
-	if len(sys.argv) > 2:
-	    streams = [ pdb.streams[int(i)] for i in sys.argv[2:] ]
-	else:
-	    streams = pdb.streams
-	    
-	for stream in streams:
-	    ofname = basename(pdb.fp.name) + ('.%03d' % stream.index)
-	    with open(ofname, 'wb') as f:
-	        f.write(stream.data)
+    pdb = pdbparse.parse(pdbfilepath, fast_load = True)
+    if len(sys.argv) > 2:
+        streams = [pdb.streams[int(i)] for i in sys.argv[2:]]
+    else:
+        streams = pdb.streams
+
+    for stream in streams:
+        ofname = basename(pdb.fp.name) + ('.%03d' % stream.index)
+        with open(ofname, 'wb') as f:
+            f.write(stream.data)
+
 
 if __name__ == "__main__":
     main(sys.argv[1])

--- a/examples/pdb_files.py
+++ b/examples/pdb_files.py
@@ -1,49 +1,43 @@
 #!/usr/bin/python
 # coding: utf-8
 
-
 import os
 import sys
 import pdbparse
 from pdbparse.peinfo import *
 from binascii import hexlify
 
-def main (pepath):
-	
-	# Extract debug infos from PE. 
-	guid, pdb_filename = get_external_codeview(pepath)
-	print("PE debug infos : %s, %s" % (pdb_filename, guid))
-	
 
-	# Extract corresponding PDB. 
-	pdbpath = os.path.join(os.path.dirname(pepath), pdb_filename)
-	p = pdbparse.parse(pdbpath, fast_load=True)	
-	pdb = p.streams[pdbparse.PDB_STREAM_PDB]
-	pdb.load()
-	guidstr = (u'%08x%04x%04x%s%x' % (
-		pdb.GUID.Data1, pdb.GUID.Data2, 
-		pdb.GUID.Data3, 
-		binascii.hexlify(pdb.GUID.Data4).decode('ascii'),
-		pdb.Age
-	)).upper()
-	print("PDB Guid : %s" % (guidstr))
+def main(pepath):
 
-	if guid != guidstr:
-		print(u'pdb not for this exe')
-		sys.exit(-1)
-	else:
-		dbi = p.streams[pdbparse.PDB_STREAM_DBI]
-		dbi.load()
+    # Extract debug infos from PE.
+    guid, pdb_filename = get_external_codeview(pepath)
+    print("PE debug infos : %s, %s" % (pdb_filename, guid))
 
-		for (i,fns) in enumerate(dbi.modules):
-			module_name = dbi.DBIExHeaders[i].objName.decode('ascii')
-			print("[%d] DBI Module : %s" % (i, module_name))
-			for fn in fns:
-				print(u'\t%s' % fn)
-			print(u'-')	
+    # Extract corresponding PDB.
+    pdbpath = os.path.join(os.path.dirname(pepath), pdb_filename)
+    p = pdbparse.parse(pdbpath, fast_load = True)
+    pdb = p.streams[pdbparse.PDB_STREAM_PDB]
+    pdb.load()
+    guidstr = (u'%08x%04x%04x%s%x' % (pdb.GUID.Data1, pdb.GUID.Data2, pdb.GUID.Data3, binascii.hexlify(
+        pdb.GUID.Data4).decode('ascii'), pdb.Age)).upper()
+    print("PDB Guid : %s" % (guidstr))
+
+    if guid != guidstr:
+        print(u'pdb not for this exe')
+        sys.exit(-1)
+    else:
+        dbi = p.streams[pdbparse.PDB_STREAM_DBI]
+        dbi.load()
+
+        for (i, fns) in enumerate(dbi.modules):
+            module_name = dbi.DBIExHeaders[i].objName.decode('ascii')
+            print("[%d] DBI Module : %s" % (i, module_name))
+            for fn in fns:
+                print(u'\t%s' % fn)
+            print(u'-')
+
 
 if __name__ == u'__main__':
-	pepath = sys.argv[1]
-	main(pepath)
-
-
+    pepath = sys.argv[1]
+    main(pepath)

--- a/examples/pdb_get_syscall_table.py
+++ b/examples/pdb_get_syscall_table.py
@@ -10,13 +10,17 @@ from pdbparse.undecorate import undecorate
 from pefile import PE
 from collections import namedtuple
 
+
 class SyscallTable(object):
+
     def __init__(self, ServiceTable, ServiceLimit, ArgumentTable):
         self.ServiceTable = ServiceTable
         self.ServiceLimit = ServiceLimit
         self.ArgumentTable = ArgumentTable
+
     def __repr__(self):
         return "SyscallTable(%s,%s,%s)" % (self.ServiceTable, self.ServiceLimit, self.ArgumentTable)
+
 
 names = [
     SyscallTable('KiServiceTable', 'KiServiceLimit', 'KiArgumentTable'),
@@ -24,17 +28,17 @@ names = [
 ]
 
 addrs = [
-    SyscallTable(0,0,0),
-    SyscallTable(0,0,0),
+    SyscallTable(0, 0, 0),
+    SyscallTable(0, 0, 0),
 ]
 
 values = [
-    SyscallTable(0,0,0),
-    SyscallTable(0,0,0),
+    SyscallTable(0, 0, 0),
+    SyscallTable(0, 0, 0),
 ]
 
 if len(sys.argv) != 3:
-    print ("usage: %s <exe> <pdb>" % sys.argv[0], file=sys.stderr)
+    print("usage: %s <exe> <pdb>" % sys.argv[0], file = sys.stderr)
     sys.exit(1)
 
 pe = PE(sys.argv[1])
@@ -44,32 +48,32 @@ gsyms = pdb.STREAM_GSYM
 omap = pdb.STREAM_OMAP_FROM_SRC
 omap_rev = pdb.STREAM_OMAP_TO_SRC
 
-for tbl,addr in zip(names,addrs):
+for tbl, addr in zip(names, addrs):
     for sym in gsyms.globals:
         if not hasattr(sym, 'offset'): continue
         try:
-            virt_base = sects[sym.segment-1].VirtualAddress
+            virt_base = sects[sym.segment - 1].VirtualAddress
         except IndexError:
             continue
         off = sym.offset
 
         if tbl.ServiceTable in sym.name:
-            value = omap.remap(off+virt_base)
+            value = omap.remap(off + virt_base)
             addr.ServiceTable = value
             #print tbl.ServiceTable,hex(omap.remap(off+virt_base))
         elif tbl.ServiceLimit in sym.name:
-            value = omap.remap(off+virt_base)
+            value = omap.remap(off + virt_base)
             addr.ServiceLimit = value
             #print tbl.ServiceLimit,hex(value)
         elif tbl.ArgumentTable in sym.name:
-            value = omap.remap(off+virt_base)
+            value = omap.remap(off + virt_base)
             addr.ArgumentTable = value
             #print tbl.ArgumentTable,hex(value)
 
-for addr,val in zip(addrs,values):
+for addr, val in zip(addrs, values):
     if not addr.ServiceTable: continue
-    limit = unpack("<L", pe.get_data(addr.ServiceLimit,4))[0]
-    functions = unpack("<%dL" % limit, pe.get_data(addr.ServiceTable, limit*4))
+    limit = unpack("<L", pe.get_data(addr.ServiceLimit, 4))[0]
+    functions = unpack("<%dL" % limit, pe.get_data(addr.ServiceTable, limit * 4))
     functions = [f - pe.OPTIONAL_HEADER.ImageBase for f in functions]
     args = unpack("<%dB" % limit, pe.get_data(addr.ArgumentTable, limit))
     #for i,f,a in zip(range(limit), functions, args):
@@ -80,27 +84,26 @@ for addr,val in zip(addrs,values):
 
 function_names = {}
 
-for i,val in enumerate(values):
+for i, val in enumerate(values):
     if not val.ServiceTable: continue
     remapped = [omap_rev.remap(f) for f in val.ServiceTable]
     for sym in gsyms.globals:
         if not hasattr(sym, 'offset'): continue
         try:
-            virt_base = sects[sym.segment-1].VirtualAddress
+            virt_base = sects[sym.segment - 1].VirtualAddress
         except IndexError:
             continue
         off = sym.offset
 
-        for j,f in enumerate(remapped):
-            if f == virt_base+off:
+        for j, f in enumerate(remapped):
+            if f == virt_base + off:
                 ordinal = i << 12 | j
                 function_names[ordinal] = sym.name
                 #print "Found %s for function %x" % (sym.name,ordinal)
 
-for i,val in enumerate(values):
+for i, val in enumerate(values):
     if not val.ServiceTable: continue
     for j in range(val.ServiceLimit):
         ordinal = i << 12 | j
-        print ("Ordinal %#06x Name: %s Args: %d (%#x bytes) Offset: %#x" % (ordinal, undecorate(function_names[ordinal])[0],
-                                                                       val.ArgumentTable[j] / 4, val.ArgumentTable[j],
-                                                                       val.ServiceTable[j]))
+        print("Ordinal %#06x Name: %s Args: %d (%#x bytes) Offset: %#x" % (ordinal, undecorate(
+            function_names[ordinal])[0], val.ArgumentTable[j] / 4, val.ArgumentTable[j], val.ServiceTable[j]))

--- a/examples/pdb_lookup.py
+++ b/examples/pdb_lookup.py
@@ -13,17 +13,17 @@ if __name__ == "__main__":
         ipy = False
 
     if len(sys.argv) < 3 or len(sys.argv[1:]) % 2 != 0:
-        print ("usage: %s <pdb> <base> [[<pdb> <base>] ...]" % sys.argv[0], file=sys.stderr)
+        print("usage: %s <pdb> <base> [[<pdb> <base>] ...]" % sys.argv[0], file = sys.stderr)
         sys.exit(1)
 
-    mods = [ (sys.argv[i],int(sys.argv[i+1],0)) for i in range(1,len(sys.argv)-1,2) ]
+    mods = [(sys.argv[i], int(sys.argv[i + 1], 0)) for i in range(1, len(sys.argv) - 1, 2)]
 
     lobj = Lookup(mods)
     lookup = lobj.lookup
-    
+
     banner = "Use lookup(addr) to resolve an address to its nearest symbol"
     if ipy:
-        shell = InteractiveShellEmbed(banner2=banner)
+        shell = InteractiveShellEmbed(banner2 = banner)
         shell()
     else:
-        code.interact(banner=banner, local=locals())
+        code.interact(banner = banner, local = locals())

--- a/examples/pdb_print_ctypes.py
+++ b/examples/pdb_print_ctypes.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 """
 This script prints the C definitions of the items found in a PDB file.
 
@@ -53,36 +52,39 @@ import pdbparse
 import random
 import pprint
 
+
 # Topological sort, by Paul Harrison
 # Found at:
 #   http://www.logarithmic.net/pfh-files/blog/01208083168/sort.py
 # License: Public domain
 def topological_sort(graph):
-    count = { }
+    count = {}
     for node in graph:
         count[node] = 0
     for node in graph:
         for successor in graph[node]:
             count[successor] += 1
 
-    ready = [ node for node in graph if count[node] == 0 ]
-    
-    result = [ ]
+    ready = [node for node in graph if count[node] == 0]
+
+    result = []
     while ready:
         node = ready.pop(-1)
         result.append(node)
-        
+
         for successor in graph[node]:
             count[successor] -= 1
             if count[successor] == 0:
                 ready.append(successor)
-    
+
     return result
+
 
 def rand_str(length):
     alphabet = "abcdefghijklmnopqrstuvwxyz"
     alphabet += alphabet.upper()
-    return "".join(random.sample(alphabet,length))
+    return "".join(random.sample(alphabet, length))
+
 
 ARCH_PTR_SIZE = None
 
@@ -99,7 +101,7 @@ fptr_str = None
 struct_pretty_str = None
 
 # Microsoft Visual Studio "theme"
-ctype_msvc  = {
+ctype_msvc = {
     "T_32PINT4": "PLONG",
     "T_32PRCHAR": "PUCHAR",
     "T_32PUCHAR": "PUCHAR",
@@ -128,7 +130,7 @@ ctype_msvc  = {
 }
 
 # Introspection "theme" for a 32-bit target
-ctype_intro  = {
+ctype_intro = {
     "T_32PINT4": "uint32_t",
     "T_32PRCHAR": "uint32_t",
     "T_32PUCHAR": "uint32_t",
@@ -156,121 +158,121 @@ ctype_intro  = {
     "T_VOID": "void",
 }
 
+
 def print_basic_types():
-    print ( "/******* Define basic Windows types *******/" )
-    print ()
-    print ( "// If compiling with gcc, use -fms-extensions" )
-    print ()
-    print ( "#include <stdint.h>" )
-    print ()
-    print ( "typedef  uint8_t     UINT8;" )
-    print ( "typedef  uint8_t     UCHAR;" )
-    print ( "typedef  uint8_t      BOOL;" )
-    print ()
-    print ( "typedef   int8_t      CHAR;" )
-    print ( "typedef   int8_t      INT8;" )
-    print ()
-    print ( "typedef uint16_t    UINT16;" )
-    print ( "typedef uint16_t    USHORT;" )
-    print ( "typedef  int16_t     SHORT;" )
-    print ()
-    print ( "typedef uint32_t    UINT32;" )
-    print ( "typedef uint32_t     ULONG;" )
-    print ( "typedef  int32_t      LONG;" )
-    print ()
-    print ( "typedef uint64_t    UINT64;" )
-    print ( "typedef uint64_t ULONGLONG;" )
-    print ( "typedef  int64_t  LONGLONG;" )
-    print ()
-    print ( "typedef uint64_t   PVOID64, PPVOID64;" )
-    print ( "typedef uint32_t   PVOID32, PPVOID32;" )
-    print ( "typedef     void      VOID;" )
-    print ()
-    print ( "#ifdef WINDOWS_USE_32_BIT_POINTERS ///////////////" )
-    print ( "// pointers occupy exactly 32 bits" )
-    print ( "typedef  UINT32     PUINT8;" )
-    print ( "typedef  UINT32     PUCHAR;" )
-    print ( "typedef  UINT32      PBOOL;" )
-    print ()
-    print ( "typedef  UINT32      PCHAR;" )
-    print ( "typedef  UINT32      PINT8;" )
-    print ()
-    print ( "typedef  UINT32    PUINT16;" )
-    print ( "typedef  UINT32    PUSHORT;" )
-    print ( "typedef  UINT32     PSHORT;" )
-    print ()
-    print ( "typedef  UINT32     PUINT32;" )
-    print ( "typedef  UINT32      PULONG;" )
-    print ( "typedef  UINT32       PLONG;" )
-    print ()
-    print ( "typedef  UINT32     PUINT64;" )
-    print ( "typedef  UINT32  PULONGLONG;" )
-    print ( "typedef  UINT32   PLONGLONG;" )
-    print ()
-    print ( "typedef  UINT32       PVOID, PPVOID;" )
-    print ()
-    print ( "#else /////////////////  !WINDOWS_USE_32_BIT_POINTERS" )
-    print ( "// pointers occupy native address width per ABI" )
-    print ( "typedef     UINT8     *PUINT8;" )
-    print ( "typedef     UCHAR     *PUCHAR;" )
-    print ( "typedef      BOOL      *PBOOL;" )
-    print ()
-    print ( "typedef      CHAR      *PCHAR;" )
-    print ( "typedef      INT8      *PINT8;" )
-    print ()
-    print ( "typedef    UINT16    *PUINT16;" )
-    print ( "typedef    USHORT    *PUSHORT;" )
-    print ( "typedef     SHORT     *PSHORT;" )
-    print ()
-    print ( "typedef    UINT32    *PUINT32;" )
-    print ( "typedef     ULONG     *PULONG;" )
-    print ( "typedef      LONG      *PLONG;" )
-    print ()
-    print ( "typedef    UINT64    *PUINT64;" )
-    print ( "typedef ULONGLONG *PULONGLONG;" )
-    print ( "typedef  LONGLONG  *PLONGLONG;" )
-    print ()
-    print ( "typedef      VOID      *PVOID, **PPVOID;" )
-    print ()
-    print ( "#endif /////////////////  WINDOWS_USE_32_BIT_POINTERS" )
-    print ( "\n\n\n" )
-    print ( "#define P(basetype, var) ( (basetype *)(var))" )
-    print ( "\n\n\n" )
+    print("/******* Define basic Windows types *******/")
+    print()
+    print("// If compiling with gcc, use -fms-extensions")
+    print()
+    print("#include <stdint.h>")
+    print()
+    print("typedef  uint8_t     UINT8;")
+    print("typedef  uint8_t     UCHAR;")
+    print("typedef  uint8_t      BOOL;")
+    print()
+    print("typedef   int8_t      CHAR;")
+    print("typedef   int8_t      INT8;")
+    print()
+    print("typedef uint16_t    UINT16;")
+    print("typedef uint16_t    USHORT;")
+    print("typedef  int16_t     SHORT;")
+    print()
+    print("typedef uint32_t    UINT32;")
+    print("typedef uint32_t     ULONG;")
+    print("typedef  int32_t      LONG;")
+    print()
+    print("typedef uint64_t    UINT64;")
+    print("typedef uint64_t ULONGLONG;")
+    print("typedef  int64_t  LONGLONG;")
+    print()
+    print("typedef uint64_t   PVOID64, PPVOID64;")
+    print("typedef uint32_t   PVOID32, PPVOID32;")
+    print("typedef     void      VOID;")
+    print()
+    print("#ifdef WINDOWS_USE_32_BIT_POINTERS ///////////////")
+    print("// pointers occupy exactly 32 bits")
+    print("typedef  UINT32     PUINT8;")
+    print("typedef  UINT32     PUCHAR;")
+    print("typedef  UINT32      PBOOL;")
+    print()
+    print("typedef  UINT32      PCHAR;")
+    print("typedef  UINT32      PINT8;")
+    print()
+    print("typedef  UINT32    PUINT16;")
+    print("typedef  UINT32    PUSHORT;")
+    print("typedef  UINT32     PSHORT;")
+    print()
+    print("typedef  UINT32     PUINT32;")
+    print("typedef  UINT32      PULONG;")
+    print("typedef  UINT32       PLONG;")
+    print()
+    print("typedef  UINT32     PUINT64;")
+    print("typedef  UINT32  PULONGLONG;")
+    print("typedef  UINT32   PLONGLONG;")
+    print()
+    print("typedef  UINT32       PVOID, PPVOID;")
+    print()
+    print("#else /////////////////  !WINDOWS_USE_32_BIT_POINTERS")
+    print("// pointers occupy native address width per ABI")
+    print("typedef     UINT8     *PUINT8;")
+    print("typedef     UCHAR     *PUCHAR;")
+    print("typedef      BOOL      *PBOOL;")
+    print()
+    print("typedef      CHAR      *PCHAR;")
+    print("typedef      INT8      *PINT8;")
+    print()
+    print("typedef    UINT16    *PUINT16;")
+    print("typedef    USHORT    *PUSHORT;")
+    print("typedef     SHORT     *PSHORT;")
+    print()
+    print("typedef    UINT32    *PUINT32;")
+    print("typedef     ULONG     *PULONG;")
+    print("typedef      LONG      *PLONG;")
+    print()
+    print("typedef    UINT64    *PUINT64;")
+    print("typedef ULONGLONG *PULONGLONG;")
+    print("typedef  LONGLONG  *PLONGLONG;")
+    print()
+    print("typedef      VOID      *PVOID, **PPVOID;")
+    print()
+    print("#endif /////////////////  WINDOWS_USE_32_BIT_POINTERS")
+    print("\n\n\n")
+    print("#define P(basetype, var) ( (basetype *)(var))")
+    print("\n\n\n")
 
-    
+
 base_type_size = {
-    "T_32PRCHAR":  4,
-    "T_32PUCHAR":  4,
-    "T_32PULONG":  4,
-    "T_32PUQUAD":  4,
+    "T_32PRCHAR": 4,
+    "T_32PUCHAR": 4,
+    "T_32PULONG": 4,
+    "T_32PUQUAD": 4,
     "T_32PUSHORT": 4,
-    "T_32PVOID":   4,
-    "T_32PLONG":   4,
-    
-    "T_64PRCHAR":  8,
-    "T_64PUCHAR":  8,
-    "T_64PULONG":  8,
-    "T_64PUQUAD":  8,
+    "T_32PVOID": 4,
+    "T_32PLONG": 4,
+    "T_64PRCHAR": 8,
+    "T_64PUCHAR": 8,
+    "T_64PULONG": 8,
+    "T_64PUQUAD": 8,
     "T_64PUSHORT": 8,
-    "T_64PVOID":   8,
-    "T_64PLONG":   8,
-
-    "T_INT4":      4,
-    "T_INT8":      8,
-    "T_LONG":      4,
-    "T_QUAD":      8,
-    "T_RCHAR":     1,
-    "T_REAL32":    4,
-    "T_REAL64":    8,
-    "T_REAL80":   10,
-    "T_SHORT":     2,
-    "T_UCHAR":     1,
-    "T_UINT4":     4,
-    "T_ULONG":     4,
-    "T_UQUAD":     8,
-    "T_USHORT":    2,
-    "T_WCHAR":     2,
+    "T_64PVOID": 8,
+    "T_64PLONG": 8,
+    "T_INT4": 4,
+    "T_INT8": 8,
+    "T_LONG": 4,
+    "T_QUAD": 8,
+    "T_RCHAR": 1,
+    "T_REAL32": 4,
+    "T_REAL64": 8,
+    "T_REAL80": 10,
+    "T_SHORT": 2,
+    "T_UCHAR": 1,
+    "T_UINT4": 4,
+    "T_ULONG": 4,
+    "T_UQUAD": 8,
+    "T_USHORT": 2,
+    "T_WCHAR": 2,
 }
+
 
 class Member:
     """
@@ -278,7 +280,8 @@ class Member:
     by the underlying parsing library or one created by this script (e.g. one
     that fills a gap found in a struct).
     """
-    def __init__(self, ofs, size, alignment, leaf_type, contents, index, suppress_meta=False):
+
+    def __init__(self, ofs, size, alignment, leaf_type, contents, index, suppress_meta = False):
         '''
         ofs - offset where Member starts
         size - size of member; could be fractional if bitfield
@@ -287,13 +290,13 @@ class Member:
         e.g.        UINT Member1 : 3;
         size is 0.375 == 3/8 (byte), alignment is 1 (byte)
         '''
-        self.ofs       = ofs
-        self.size      = size
+        self.ofs = ofs
+        self.size = size
         self.alignment = alignment
         self.leaf_type = leaf_type
-        self.contents  = contents
-        self.index     = index
-        self.suppress  = suppress_meta
+        self.contents = contents
+        self.index = index
+        self.suppress = suppress_meta
 
     def __str__(self):
         if self.suppress:
@@ -308,32 +311,34 @@ class Member:
     def comment_str(self):
         # Not suppressing metadata, so calculate it now.
         if self.leaf_type == 'LF_BITFIELD':
-            ofs_str  = '{0:>5}'.format(self.ofs)
+            ofs_str = '{0:>5}'.format(self.ofs)
             size_str = '{0:>5}'.format(self.size)
 
-            if  self.ofs != 0 and int(self.ofs) == self.ofs: # ofs is an int, show it in hex too
+            if self.ofs != 0 and int(self.ofs) == self.ofs:  # ofs is an int, show it in hex too
                 ofs_str += ' [{0:#x}]'.format(int(self.ofs))
-        else: # not a bitfield - assume integer size & offset
-            ofs_str  = '{0:>5}'.format(hex(int(self.ofs)))
+        else:  # not a bitfield - assume integer size & offset
+            ofs_str = '{0:>5}'.format(hex(int(self.ofs)))
             size_str = '{0:>5}'.format(hex(int(self.size)))
-            
+
         # display member's metadata
         return '// offset {0} size {1}'.format(ofs_str, size_str)
-    
+
     def __len__(self):
         return self.size
-    
+
+
 class OneRun:
     """
     Describes one run. A run is a fundamental concept in this code -- it is a
     sequence of Member objects that appear consecutively (i.e. they have
     increasing offsets with no gaps between them).
     """
+
     def __init__(self, ofs):
-        self.members   = list() # list consisting only of Members
-        self.ofs       = ofs
-        self.ltype     = 'LF_STRUCTURE'
-        self.next_ofs  = ofs
+        self.members = list()  # list consisting only of Members
+        self.ofs = ofs
+        self.ltype = 'LF_STRUCTURE'
+        self.next_ofs = ofs
 
     def next_ofs(self):
         return self.ofs + len(self)
@@ -342,16 +347,16 @@ class OneRun:
         return sum([x.size for x in self.members])
 
     def __str__(self):
-        return ('// Sequential members from 0x%x to 0x%x (length 0x%x bytes)\n'
-                % (self.ofs, self.next_ofs(), len(self)) +
-                '\n'.join([str(m) for m in self.members]))
+        return ('// Sequential members from 0x%x to 0x%x (length 0x%x bytes)\n' % (self.ofs, self.next_ofs(), len(self))
+                + '\n'.join([str(m) for m in self.members]))
 
-    def add_member(self,m):
+    def add_member(self, m):
         self.members.append(m)
 
-    def add_members(self,ms):
+    def add_members(self, ms):
         for m in ms:
             self.add_member(m)
+
 
 def is_function_pointer(lf):
     if isinstance(lf, str):
@@ -363,11 +368,11 @@ def is_function_pointer(lf):
     else:
         return False
 
+
 def is_inline_struct(lf):
     if isinstance(lf, str): return False
-    if (lf.leaf_type == "LF_STRUCTURE" or
-        lf.leaf_type == "LF_UNION" or
-        lf.leaf_type == "LF_ENUM") and "unnamed" in lf.name:
+    if (lf.leaf_type == "LF_STRUCTURE" or lf.leaf_type == "LF_UNION"
+            or lf.leaf_type == "LF_ENUM") and "unnamed" in lf.name:
         return True
     else:
         try:
@@ -376,16 +381,19 @@ def is_inline_struct(lf):
             pass
     return False
 
+
 def proc_arglist(proc):
     argstrs = []
     for a in proc.arglist.arg_type:
         argstrs.append(get_tpname(a))
     return argstrs
 
-def fptr_str_intro(fptr,name):
+
+def fptr_str_intro(fptr, name):
     return "uint32_t %s" % name
 
-def fptr_str_std(fptr,name):
+
+def fptr_str_std(fptr, name):
     stars = ""
     while fptr.leaf_type == "LF_POINTER":
         stars += "*"
@@ -394,20 +402,21 @@ def fptr_str_std(fptr,name):
     arglist = proc_arglist(fptr)
     return "%s (%s%s)(%s)" % (ret_type, stars, name, ", ".join(arglist))
 
+
 def demangle(nm):
     if nm.startswith("_"): return nm[1:]
     else: return nm
+
 
 def mangle(nm):
     if not nm.startswith("_"): return "_" + nm
     else: return nm
 
+
 def get_size(lf):
-    if isinstance(lf,str):
+    if isinstance(lf, str):
         return base_type_size[lf]
-    elif (lf.leaf_type == "LF_STRUCTURE" or
-          lf.leaf_type == "LF_ARRAY" or
-          lf.leaf_type == "LF_UNION"):
+    elif (lf.leaf_type == "LF_STRUCTURE" or lf.leaf_type == "LF_ARRAY" or lf.leaf_type == "LF_UNION"):
         return lf.size
     elif lf.leaf_type == "LF_POINTER":
         return ARCH_PTR_SIZE
@@ -418,15 +427,14 @@ def get_size(lf):
     elif lf.leaf_type == "LF_BITFIELD":
         return 1.0 * lf.length / 8
     else:
-        print ("ERROR: don't know how to get size for %s" % lf.leaf_type, file=sys.stderr)
+        print("ERROR: don't know how to get size for %s" % lf.leaf_type, file = sys.stderr)
         return -1
+
 
 def get_basetype(lf):
     if isinstance(lf, str):
         return None
-    elif (lf.leaf_type == "LF_STRUCTURE" or
-          lf.leaf_type == "LF_ENUM" or
-          lf.leaf_type == "LF_UNION"):
+    elif (lf.leaf_type == "LF_STRUCTURE" or lf.leaf_type == "LF_ENUM" or lf.leaf_type == "LF_UNION"):
         return lf
     elif lf.leaf_type == "LF_POINTER":
         return get_basetype(lf.utype)
@@ -437,54 +445,60 @@ def get_basetype(lf):
     else:
         return None
 
-def get_tpname(lf, name=None):
+
+def get_tpname(lf, name = None):
     if isinstance(lf, str):
-        try: tpname = ctype[lf]
-        except KeyError: tpname = lf
+        try:
+            tpname = ctype[lf]
+        except KeyError:
+            tpname = lf
         if name: tpname += " " + name
-    elif (lf.leaf_type == "LF_STRUCTURE" or
-          lf.leaf_type == "LF_ENUM" or
-          lf.leaf_type == "LF_UNION"):
+    elif (lf.leaf_type == "LF_STRUCTURE" or lf.leaf_type == "LF_ENUM" or lf.leaf_type == "LF_UNION"):
         tpname = demangle(lf.name)
         if name: tpname += " " + name
-    elif lf.leaf_type == "LF_POINTER":   tpname = ptr_str(lf,name)
-    elif lf.leaf_type == "LF_PROCEDURE": tpname = proc_str(lf,name)
-    elif lf.leaf_type == "LF_MODIFIER":  tpname = mod_str(lf,name)
-    elif lf.leaf_type == "LF_ARRAY":     tpname = arr_str(lf,name)
-    elif lf.leaf_type == "LF_BITFIELD":  tpname = bit_str(lf,name)
+    elif lf.leaf_type == "LF_POINTER": tpname = ptr_str(lf, name)
+    elif lf.leaf_type == "LF_PROCEDURE": tpname = proc_str(lf, name)
+    elif lf.leaf_type == "LF_MODIFIER": tpname = mod_str(lf, name)
+    elif lf.leaf_type == "LF_ARRAY": tpname = arr_str(lf, name)
+    elif lf.leaf_type == "LF_BITFIELD": tpname = bit_str(lf, name)
     else:
         tpname = lf.leaf_type
         if name: tpname += " " + name
     return tpname
 
+
 def bit_str(bitf, name):
     return "%s %s : %d" % (get_tpname(bitf.base_type), name, bitf.length)
+
 
 def arr_str(arr, name):
     tpname = get_tpname(arr.element_type)
     sz = get_size(arr.element_type)
     if sz == 0:
-        print ("ERROR with array %s %s" % (tpname, name), file=sys.stderr)
+        print("ERROR with array %s %s" % (tpname, name), file = sys.stderr)
     if sz < 0:
-        print ("ERROR with array %s %s -- element size is negative" % (tpname, name), file=sys.stderr)
+        print("ERROR with array %s %s -- element size is negative" % (tpname, name), file = sys.stderr)
     if arr.size < 0:
-        print ("ERROR with array %s %s -- size is negative" % (tpname, name), file=sys.stderr)
+        print("ERROR with array %s %s -- size is negative" % (tpname, name), file = sys.stderr)
     count = arr.size / sz
-    return memb_str(arr.element_type, "%s[0x%x]" % (name,count))
+    return memb_str(arr.element_type, "%s[0x%x]" % (name, count))
     #return "%s %s[%d]" % (tpname, name, count)
+
 
 def mod_str(mod, name):
     tpname = get_tpname(mod.modified_type)
-    modifiers = [ m for m in ["const","unaligned","volatile"] if mod.modifier[m]]
+    modifiers = [m for m in ["const", "unaligned", "volatile"] if mod.modifier[m]]
     tpname = "%s %s" % (" ".join(modifiers), tpname)
     if name: tpname += " " + name
     return tpname
+
 
 def ptr_str_intro(ptr, name):
     if name:
         return "uint32_t %s" % name
     else:
         return "uint32_t"
+
 
 def ptr_str_std(ptr, name):
     tpname = get_tpname(ptr.utype)
@@ -497,7 +511,7 @@ def ptr_str_std(ptr, name):
 
         # Handle pointer with modifier - the modifier goes to the beginning
         mods = list()
-        for m in ("const","unaligned","volatile"):
+        for m in ("const", "unaligned", "volatile"):
             if tpname.find(m) > -1:
                 mods.append(m)
                 tpname = tpname.replace(m + ' ', '')
@@ -506,13 +520,15 @@ def ptr_str_std(ptr, name):
     else:
         return "P%s" % tpname
 
+
 def proc_str(proc, name):
     argstrs = proc_arglist(proc)
     ret_type = get_tpname(proc.return_type)
     if not name: name = "func_" + rand_str(5)
     return "%s (*%s)(%s)" % (ret_type, name, ", ".join(argstrs))
 
-def memb_str(memb, name, off=-1):
+
+def memb_str(memb, name, off = -1):
     if is_function_pointer(memb):
         tpname = fptr_str(memb, name)
     elif is_inline_struct(memb):
@@ -529,7 +545,7 @@ def memb_str(memb, name, off=-1):
         ofs_str = '%#x' % off
         size_str = '%#x' % size
         alignment = 0
-        if not isinstance(memb,str):
+        if not isinstance(memb, str):
             ltype = memb.leaf_type
             length = memb.length
             if memb.leaf_type == 'LF_BITFIELD':
@@ -540,7 +556,7 @@ def memb_str(memb, name, off=-1):
                     btype = memb['base_type']
                 else:
                     btype = memb['base_type']['modified_type']
-                
+
                 alignment = base_type_size[btype]
 
         return (off, size, alignment, ltype, "%s;" % tpname)
@@ -548,11 +564,11 @@ def memb_str(memb, name, off=-1):
         return "%s" % (tpname)
 
 
-
 def size_of_one_run(run):
     return sum([x.size for x in run])
 
-def size_from_offset_map(offset_map, comment_list, offset_of_interest=None):
+
+def size_from_offset_map(offset_map, comment_list, offset_of_interest = None):
     tot_size = 0
 
     if offset_of_interest:
@@ -565,17 +581,17 @@ def size_from_offset_map(offset_map, comment_list, offset_of_interest=None):
         if offset_of_interest and i is not offset_of_interest:
             continue
         elif i != tot_size:
-            comment_list.append("// Size vs offset misalignment at offset 0x%x (curr size 0x%x)"
-                                % (i, tot_size))
-        
-        runs_ll = offset_map[i] # list of lists
+            comment_list.append("// Size vs offset misalignment at offset 0x%x (curr size 0x%x)" % (i, tot_size))
+
+        runs_ll = offset_map[i]  # list of lists
 
         # size of union is max of its components
         #tot_size += max ([len(x) for x in runs_ll])
-        tot_size += max ([size_of_one_run(x) for x in runs_ll])
-        
+        tot_size += max([size_of_one_run(x) for x in runs_ll])
+
     return tot_size
-        
+
+
 def member_list_from_offset_map(offset_map, leaf_type):
     """
     Generate member_list suitable for flstr() from the offset map generated in
@@ -586,15 +602,15 @@ def member_list_from_offset_map(offset_map, leaf_type):
     starts = offset_map.keys()
     starts.sort()
 
-    for ofs in starts: # i is either a scalar or a list
+    for ofs in starts:  # i is either a scalar or a list
         # runs is a list of lists
         runs = offset_map[ofs]
 
         # how many items in sublist? 1 ==> emit it, 2+ ==> put in union
-        if len(runs) == 1: # one run at this offset
+        if len(runs) == 1:  # one run at this offset
             for member in runs[0]:
                 my_mlist.append(str(member))
-        else: # multiple runs at this offset
+        else:  # multiple runs at this offset
             if leaf_type is not 'LF_UNION':
                 union_str = "union {\n"
             else:
@@ -602,59 +618,64 @@ def member_list_from_offset_map(offset_map, leaf_type):
             sizes = list()
             for member in runs:
                 if len(member) == 1:
-                    union_str += str(member[0]) +'\n'
+                    union_str += str(member[0]) + '\n'
                     sizes.append(member[0].size)
                 else:
                     struct_size = sum([x.size for x in member])
                     sizes.append(struct_size)
-                    
-                    struct =  ('struct { // offset 0x%x\n' % member[0].ofs +
-                               '\n'.join([str(x) for x in member]) + '\n' +
-                               '}; // struct size 0x%x\n' % struct_size )
-                    union_str += struct
-                    
-            if leaf_type is not 'LF_UNION':
-                union_str += '};' ### // union size 0x%x' % max(sizes)
 
-            my_mlist.append (union_str)
+                    struct = ('struct { // offset 0x%x\n' % member[0].ofs + '\n'.join([str(x) for x in member]) + '\n' +
+                              '}; // struct size 0x%x\n' % struct_size)
+                    union_str += struct
+
+            if leaf_type is not 'LF_UNION':
+                union_str += '};'  ### // union size 0x%x' % max(sizes)
+
+            my_mlist.append(union_str)
 
     return my_mlist
 
+
 def is_bitfield(member):
-    if member is None: 
+    if member is None:
         return False
-    if not isinstance(member,Member):
+    if not isinstance(member, Member):
         return False
-    
+
     return member.leaf_type == 'LF_BITFIELD'
 
+
 def member_ofs_appears_later(mbr, members):
-    return len([x for x in members [mbr.index+1:] if x.ofs == mbr.ofs]) > 0
-    
+    return len([x for x in members[mbr.index + 1:] if x.ofs == mbr.ofs]) > 0
+
+
 def generate_gap_member(ofs, size, gap_ct):
-    assert size>0, "invalid size for gap"
+    assert size > 0, "invalid size for gap"
     name = 'UINT8 unknown%d[%#x];' % (gap_ct, size)
     return Member(ofs, size, None, name, 0)
+
 
 def flush_run_to_map(offset_map, run):
     if len(run) > 0:
         if run.ofs not in offset_map:
             offset_map[run.ofs] = list()
-        offset_map[run.ofs].append ([m for m in run.members])
+        offset_map[run.ofs].append([m for m in run.members])
+
 
 def fix_bitfield_offsets(members):
     i = 1
     while i < len(members):
         this = members[i]
-        prev = members[i-1]
+        prev = members[i - 1]
 
         if is_bitfield(this) and is_bitfield(prev):
             this.ofs = prev.ofs + prev.size
         i += 1
 
+
 def merge_bitfield_sequences(members):
 
-    def get_aligned_size (sz, alignment):
+    def get_aligned_size(sz, alignment):
         floor_int = int(sz)
         if sz == floor_int:
             sz_int = int(sz)
@@ -662,41 +683,45 @@ def merge_bitfield_sequences(members):
             # round up to nearest int
             sz_int = int(sz + 1)
 
-
-        if sz_int & (alignment-1) == 0:
+        if sz_int & (alignment - 1) == 0:
             aligned = sz_int
         else:
-            aligned = int ((sz_int + alignment) / alignment)
+            aligned = int((sz_int + alignment) / alignment)
 
         return aligned
 
     new_members = list()
     in_bitfield = False
     bf_member = None
-    
+
     i = 0
     idx = 0
     while i < len(members):
         curr = members[i]
-        
+
         if is_bitfield(curr):
             if in_bitfield:
                 bf_member.contents += str(curr) + '\n'
-                bf_member.size     += curr.size
-            else: # new bitfield sequence
+                bf_member.size += curr.size
+            else:  # new bitfield sequence
                 in_bitfield = True
-                bf_member = Member(curr.ofs, curr.size, curr.alignment,
-                                   'LF_STRUCTURE', 'struct { // bitfield(s)\n',
-                                   i, suppress_meta=True)
+                bf_member = Member(
+                    curr.ofs,
+                    curr.size,
+                    curr.alignment,
+                    'LF_STRUCTURE',
+                    'struct { // bitfield(s)\n',
+                    i,
+                    suppress_meta = True)
                 bf_member.idx = idx
                 idx += 1
 
                 bf_member.contents += str(curr) + '\n'
-                
-        else: # not a bitfield
+
+        else:  # not a bitfield
             if in_bitfield:
                 in_bitfield = False
-                bf_member.size = get_aligned_size (bf_member.size, bf_member.alignment)
+                bf_member.size = get_aligned_size(bf_member.size, bf_member.alignment)
                 bf_member.contents += '};'
                 new_members.append(bf_member)
                 bf_member = None
@@ -709,17 +734,20 @@ def merge_bitfield_sequences(members):
 
     if bf_member is not None:
         bf_member.contents += '};'
-        bf_member.size = get_aligned_size (bf_member.size, bf_member.alignment)
+        bf_member.size = get_aligned_size(bf_member.size, bf_member.alignment)
         new_members.append(bf_member)
-        
+
     return new_members
 
+
 class Solution:
+
     def __init__(self):
         self.computed_size = None
-        self.claimed_size  = None
-        self.mlist         = list()
-        self.comments      = list()
+        self.claimed_size = None
+        self.mlist = list()
+        self.comments = list()
+
 
 def fill_gaps(lf, members, mbr_ct_by_ofs):
     '''
@@ -727,7 +755,7 @@ def fill_gaps(lf, members, mbr_ct_by_ofs):
     '''
 
     new_mlist = list()
-    
+
     ofs = 0
     while ofs < lf.size:
         try:
@@ -738,21 +766,21 @@ def fill_gaps(lf, members, mbr_ct_by_ofs):
             # HERE: There's a bare spot. -----------------
 
             # Where does the bare spot end?
-            j = ofs+1
+            j = ofs + 1
             while j < lf.size:
                 if mbr_ct_by_ofs[j] != 0:
                     break
                 j += 1
-                
+
             # [ofs:j) is bare
-            gap_size = j-ofs
+            gap_size = j - ofs
             gap_name = ('UINT8 gap_in_pdb_ofs_%X[%#x];' % (ofs, gap_size))
 
             gap_filler = Member(ofs, gap_size, None, None, gap_name, 0)
 
             # Insert gap_filler into members at right spot.
-            
-            mbr_ct_by_ofs[ofs:j] = [1] * gap_size # now there's one member in this range.
+
+            mbr_ct_by_ofs[ofs:j] = [1] * gap_size  # now there's one member in this range.
 
             # Calcule the right spot to insert the gap filler.
             k = 0
@@ -761,31 +789,33 @@ def fill_gaps(lf, members, mbr_ct_by_ofs):
                 m = members[k]
                 k += 1
 
-                if m.ofs > ofs: # m is first member beyond bare spot
-                    members.insert (k-1, gap_filler)
+                if m.ofs > ofs:  # m is first member beyond bare spot
+                    members.insert(k - 1, gap_filler)
                     break
-            if k == len(members): # gap is at end
+            if k == len(members):  # gap is at end
                 members.append(gap_filler)
-                
+
             ofs += gap_size
-            
+
         except ValueError:
             break
-    
+
+
 def unionize_compute(lf, member_list):
     if lf.leaf_type == 'LF_ENUM':
         s = Solution()
-        return s # empty mlist
-        
+        return s  # empty mlist
+
     this_run = OneRun(0)
-    gap_ct = 0 # 
-    
+    gap_ct = 0  #
+
     # maps an offset to a list of runs starting at that offset. Multiple runs
     # at one offset indicate a union, whereas one run indicates non-union
     # member(s).
-    offset_map = dict() 
-    raw_members = [Member(ofs,size,align,ltype,s,idx)
-                   for idx,(ofs,size,align,ltype,s) in enumerate(member_list)]
+    offset_map = dict()
+    raw_members = [
+        Member(ofs, size, align, ltype, s, idx) for idx, (ofs, size, align, ltype, s) in enumerate(member_list)
+    ]
 
     fix_bitfield_offsets(raw_members)
 
@@ -794,28 +824,28 @@ def unionize_compute(lf, member_list):
     offsets = [x.ofs for x in members]
     #byte_ct = max([x.ofs + x.size for x in members])
     byte_ct = lf.size
-    
+
     # count how many members occupy each offset
     mbr_ct_by_ofs = [0] * byte_ct
     for m in members:
-        for ofs in range(m.ofs, m.ofs+m.size):
+        for ofs in range(m.ofs, m.ofs + m.size):
             mbr_ct_by_ofs[ofs] += 1
 
     # fix indices
-    for i,m in enumerate(members):
+    for i, m in enumerate(members):
         m.index = i
 
-    fill_gaps (lf, members, mbr_ct_by_ofs)
+    fill_gaps(lf, members, mbr_ct_by_ofs)
 
     member_ct = len(members)
 
     # fix indices
-    for i,m in enumerate(members):
+    for i, m in enumerate(members):
         m.index = i
 
     #if lf.name == '_MM_PAGE_ACCESS_INFO_HEADER':
     #    import pdb;pdb.set_trace()
-        
+
     runs = list()
     i = 0
     while i < member_ct:
@@ -826,7 +856,7 @@ def unionize_compute(lf, member_list):
         this_run.add_member(basembr)
 
         i += 1
-        if not (i < member_ct): # walked off end of list
+        if not (i < member_ct):  # walked off end of list
             break
 
         # This run goes until
@@ -845,9 +875,9 @@ def unionize_compute(lf, member_list):
         #if member_ofs_appears_later(m, members):
         #    runs.append(this_run)
         #    this_run = OneRun(m.ofs)
-                        
+
         while (i < member_ct and prev_ofs < m.ofs):
-            if member_ofs_appears_later(m,members):
+            if member_ofs_appears_later(m, members):
                 # offset appears later, m can't be in current run
                 break
 
@@ -859,37 +889,36 @@ def unionize_compute(lf, member_list):
             this_run.add_member(m)
 
             i += 1
-            if not (i < member_ct): # walked off end of list
+            if not (i < member_ct):  # walked off end of list
                 break
 
             prev_ofs = m.ofs
             m = members[i]
 
         # add remaining members in current run
-        if this_run.members: # transfer any remaining members to offset_map
+        if this_run.members:  # transfer any remaining members to offset_map
             runs.append(this_run)
             this_run = None
 
     # move this run over to runs
-    if this_run and this_run.members: 
+    if this_run and this_run.members:
         runs.append(this_run)
 
     # transfer any remaining members to offset_map
     for r in runs:
         flush_run_to_map(offset_map, r)
-        
+
     new_mlist = member_list_from_offset_map(offset_map, lf.leaf_type)
 
     s = Solution()
-    s.computed_size = size_from_offset_map(offset_map,s.comments)
-    s.claimed_size  = lf.size
-    
-    if s.computed_size != s.claimed_size:
-        s.comments.append ("// ************ INCORRECT SIZE *************************")
-        s.comments.append ("// claimed in PDB: 0x%x, calculated: 0x%x"
-                           % (s.claimed_size,s.computed_size))
+    s.computed_size = size_from_offset_map(offset_map, s.comments)
+    s.claimed_size = lf.size
 
-         # e.g. VISTA SP2 x86_32: ntdll.pdb(struct _DISPATCHER_HEADER)
+    if s.computed_size != s.claimed_size:
+        s.comments.append("// ************ INCORRECT SIZE *************************")
+        s.comments.append("// claimed in PDB: 0x%x, calculated: 0x%x" % (s.claimed_size, s.computed_size))
+
+        # e.g. VISTA SP2 x86_32: ntdll.pdb(struct _DISPATCHER_HEADER)
         new_mlist.insert(0, '/*')
         new_mlist.append('*/')
         new_mlist.append('UINT8 blob[0x%x]; // print_ctypes.py validation failure' % lf.size)
@@ -897,23 +926,22 @@ def unionize_compute(lf, member_list):
     s.mlist = new_mlist
     return s
 
-    
+
 def flstr(lf):
     flstr = ""
-    memb_strs = [ memb_str(s.index,s.name,s.offset) for s in lf.fieldlist.substructs
-                  if s.leaf_type == "LF_MEMBER" ]
+    memb_strs = [memb_str(s.index, s.name, s.offset) for s in lf.fieldlist.substructs if s.leaf_type == "LF_MEMBER"]
 
     sol = unionize_compute(lf, memb_strs)
 
     if sol.comments:
         flstr += '\n'.join(sol.comments) + '\n'
-        
-    level = 1 # indentation level
-    for i,m in enumerate(sol.mlist):
+
+    level = 1  # indentation level
+    for i, m in enumerate(sol.mlist):
         #eol = '\n' if i < len(sol.mlist)-1 else ''
-        eol = '\n' # figure out bad formatting caused by above line
-        
-        if isinstance(m,list):
+        eol = '\n'  # figure out bad formatting caused by above line
+
+        if isinstance(m, list):
             for um in m:
                 sl = um.splitlines()
                 for u in sl:
@@ -921,7 +949,7 @@ def flstr(lf):
                     if '}' in u:
                         level -= 1
 
-                    flstr += indent*(level) + lstr + eol
+                    flstr += indent * (level) + lstr + eol
                     if '{' in u:
                         level += 1
         else:
@@ -932,19 +960,21 @@ def flstr(lf):
                 if '}' in u:
                     level -= 1
 
-                flstr += indent*(level) + lstr + eol
+                flstr += indent * (level) + lstr + eol
                 if '{' in u:
                     level += 1
 
-    enum_membs = [ e for e in lf.fieldlist.substructs if e.leaf_type == "LF_ENUMERATE" ]
-    for i,e in enumerate(enum_membs):
+    enum_membs = [e for e in lf.fieldlist.substructs if e.leaf_type == "LF_ENUMERATE"]
+    for i, e in enumerate(enum_membs):
         comma = ",\n" if i < len(enum_membs) - 1 else ""
-        flstr += '{0}{1:<70} = {2:>4}{3}'.format(indent, e.name, e.enum_value, comma)#indent + "%s = %s%s\n" % (e.name, e_val, comma)
+        flstr += '{0}{1:<70} = {2:>4}{3}'.format(indent, e.name, e.enum_value,
+                                                 comma)  #indent + "%s = %s%s\n" % (e.name, e_val, comma)
     return flstr
+
 
 def struct_dependencies(lf):
     deps = set()
-    members = [ s for s in lf.fieldlist.substructs if s.leaf_type == "LF_MEMBER" ]
+    members = [s for s in lf.fieldlist.substructs if s.leaf_type == "LF_MEMBER"]
     for memb in members:
         base = get_basetype(memb.index)
         if base and not (memb.index.leaf_type == "LF_POINTER"):
@@ -954,32 +984,36 @@ def struct_dependencies(lf):
                 deps.add(base.name)
     return deps
 
+
 def struct_pretty_str_fwd(lf, gcc):
-    print ("%s %s { // %#x bytes" % (snames[lf.leaf_type], mangle(lf.name), lf.size))
-    print (flstr(lf))
+    print("%s %s { // %#x bytes" % (snames[lf.leaf_type], mangle(lf.name), lf.size))
+    print(flstr(lf))
     if gcc:
-        print ("} __attribute__((packed));")
+        print("} __attribute__((packed));")
     else:
-        print ("};")
+        print("};")
     print
 
+
 def struct_pretty_str_nofwd(lf, gcc):
-    print ("typedef %s %s { // %#x bytes" % (snames[lf.leaf_type], mangle(lf.name), lf.size))
-    print (flstr(lf))
+    print("typedef %s %s { // %#x bytes" % (snames[lf.leaf_type], mangle(lf.name), lf.size))
+    print(flstr(lf))
     if gcc:
-        print ("} __attribute__((packed)) %s, *P%s, **PP%s ;" % ((demangle(lf.name),)*3))
+        print("} __attribute__((packed)) %s, *P%s, **PP%s ;" % ((demangle(lf.name), ) * 3))
     else:
-        print ("} %s, *P%s, **PP%s ;" % ((demangle(lf.name),)*3))
+        print("} %s, *P%s, **PP%s ;" % ((demangle(lf.name), ) * 3))
     print
+
 
 def enum_pretty_str(enum):
     #if not enum.name.startswith("_"):
     #    name = "_" + enum.name
     #else: name = enum.name
-    print ("typedef enum %s {" % mangle(enum.name))
-    print (flstr(enum))
-    print ("} %s;" % demangle(enum.name))
-    print ()
+    print("typedef enum %s {" % mangle(enum.name))
+    print(flstr(enum))
+    print("} %s;" % demangle(enum.name))
+    print()
+
 
 themes = {
     "msvc": ctype_msvc,
@@ -1001,33 +1035,44 @@ if __name__ == "__main__":
     from optparse import OptionParser
     parser = OptionParser()
 
-    parser.add_option("-g", "--gcc", dest="gcc",
-                      help="emit code to assist in compilation under gcc (e.g. \"typedef uint32_t UINT32\")",
-                      action="store_true", default=False)
-    parser.add_option("-m", "--macroguard", dest="macroguard",
-                      help="emit macroguards around output",
-                      action="store_true", default=False)
-    parser.add_option("-t", "--theme", dest="theme",
-                      help="theme to use for C types [%s]" % ", ".join(themes),
-                      default="msvc")
-    parser.add_option("-f", "--fwdrefs", dest="fwdrefs", action="store_true",
-                      help="emit forward references", default=False)
-    parser.add_option("-w", "--width", dest="width",
-                      help="set pointer width for PDB's target architecture",
-                      type="int", default=None)
-    
-    opts,args = parser.parse_args()
+    parser.add_option(
+        "-g",
+        "--gcc",
+        dest = "gcc",
+        help = "emit code to assist in compilation under gcc (e.g. \"typedef uint32_t UINT32\")",
+        action = "store_true",
+        default = False)
+    parser.add_option(
+        "-m",
+        "--macroguard",
+        dest = "macroguard",
+        help = "emit macroguards around output",
+        action = "store_true",
+        default = False)
+    parser.add_option(
+        "-t", "--theme", dest = "theme", help = "theme to use for C types [%s]" % ", ".join(themes), default = "msvc")
+    parser.add_option(
+        "-f", "--fwdrefs", dest = "fwdrefs", action = "store_true", help = "emit forward references", default = False)
+    parser.add_option(
+        "-w",
+        "--width",
+        dest = "width",
+        help = "set pointer width for PDB's target architecture",
+        type = "int",
+        default = None)
+
+    opts, args = parser.parse_args()
     ctype = themes[opts.theme]
     ptr_str = theme_func[opts.theme]["ptr_str"]
     fptr_str = theme_func[opts.theme]["fptr_str"]
     if opts.fwdrefs:
         struct_pretty_str = struct_pretty_str_fwd
     else:
-        struct_pretty_str =  struct_pretty_str_nofwd
+        struct_pretty_str = struct_pretty_str_nofwd
 
     if opts.fwdrefs:
-        pdb = pdbparse.parse(args[0], fast_load=True)
-        pdb.streams[2].load(elim_fwdrefs=False)
+        pdb = pdbparse.parse(args[0], fast_load = True)
+        pdb.streams[2].load(elim_fwdrefs = False)
     else:
         pdb = pdbparse.parse(args[0])
 
@@ -1042,52 +1087,49 @@ if __name__ == "__main__":
 
             # sets global ARCH_PTR_SIZE
             if pdb.STREAM_DBI.machine in ('IMAGE_FILE_MACHINE_I386'):
-                print ("// Architecture pointer width 4 bytes")
+                print("// Architecture pointer width 4 bytes")
                 ARCH_PTR_SIZE = 4
-            elif pdb.STREAM_DBI.machine in ('IMAGE_FILE_MACHINE_AMD64',
-                                            'IMAGE_FILE_MACHINE_IA64'):
-                print ("// Architecture pointer width 8 bytes")
+            elif pdb.STREAM_DBI.machine in ('IMAGE_FILE_MACHINE_AMD64', 'IMAGE_FILE_MACHINE_IA64'):
+                print("// Architecture pointer width 8 bytes")
                 ARCH_PTR_SIZE = 8
 
         except:
-            sys.stderr.write ("Failed to find arch pointer width. Use the -w option.")
+            sys.stderr.write("Failed to find arch pointer width. Use the -w option.")
             raise
 
-
-            
     if opts.macroguard:
         macroguard_str = "_WINDOWS_PDB_" + os.path.basename(args[0]).replace('.', '_') + "_defns"
-        print ("#ifndef %s" % macroguard_str)
-        print ("#define %s" % macroguard_str)
-        print ()
+        print("#ifndef %s" % macroguard_str)
+        print("#define %s" % macroguard_str)
+        print()
 
     if opts.gcc:
         print_basic_types()
-        
+
     if opts.fwdrefs:
-        fwdrefs = [ s for s in pdb.streams[2].types.values()
-                    if s.leaf_type in ("LF_STRUCTURE","LF_UNION") and s.prop.fwdref ]
-        print ("/******* Forward Refs *******/")
+        fwdrefs = [
+            s for s in pdb.streams[2].types.values() if s.leaf_type in ("LF_STRUCTURE", "LF_UNION") and s.prop.fwdref
+        ]
+        print("/******* Forward Refs *******/")
         for f in fwdrefs:
-            print ("%s %s;" % (snames[f.leaf_type], mangle(f.name)))
+            print("%s %s;" % (snames[f.leaf_type], mangle(f.name)))
             print ("typedef %s %s %s;" % \
                 (snames[f.leaf_type], mangle(f.name),demangle(f.name)))
-            print ("#ifdef WINDOWS_USE_32_BIT_POINTERS")
+            print("#ifdef WINDOWS_USE_32_BIT_POINTERS")
             print ("   typedef %s P%s, PP%s; // pointers take up 32 bits" % \
                 ("UINT32", demangle(f.name), demangle(f.name)))
-            print ("#else")
-            print ("   typedef %s *P%s, **PP%s;" % ((demangle(f.name),)*3))
-            print ("#endif")
-            print ()
+            print("#else")
+            print("   typedef %s *P%s, **PP%s;" % ((demangle(f.name), ) * 3))
+            print("#endif")
+            print()
 
         # Reload the file without fwdrefs as it messes up type sizes
         pdb = pdbparse.parse(args[0])
 
-    structs = [ s for s in pdb.streams[2].types.values()
-                if (s.leaf_type in ("LF_STRUCTURE","LF_UNION")
-                    and not s.prop.fwdref ) ]
-    enums = [ e for e in pdb.streams[2].types.values()
-              if e.leaf_type == "LF_ENUM" and not e.prop.fwdref ]
+    structs = [
+        s for s in pdb.streams[2].types.values() if (s.leaf_type in ("LF_STRUCTURE", "LF_UNION") and not s.prop.fwdref)
+    ]
+    enums = [e for e in pdb.streams[2].types.values() if e.leaf_type == "LF_ENUM" and not e.prop.fwdref]
 
     dep_graph = {}
     names = {}
@@ -1095,15 +1137,15 @@ if __name__ == "__main__":
         if "unnamed" in s.name: continue
         dep_graph[s.name] = struct_dependencies(s)
         names[s.name] = s
-    dep_graph.update((e.name,[]) for e in enums)
+    dep_graph.update((e.name, []) for e in enums)
     structs = topological_sort(dep_graph)
     structs.reverse()
 
-    print ("/******* Enumerations *******/")
+    print("/******* Enumerations *******/")
     for e in enums:
         enum_pretty_str(e)
 
-    print ("/*******  Structures  *******/")
+    print("/*******  Structures  *******/")
     for n in names:
         s = names[n]
         if "unnamed" in s.name: continue
@@ -1111,4 +1153,4 @@ if __name__ == "__main__":
         struct_pretty_str(s, opts.gcc)
 
     if opts.macroguard:
-        print ("#endif // #define %s" % macroguard_str)
+        print("#endif // #define %s" % macroguard_str)

--- a/examples/pdb_print_gvars.py
+++ b/examples/pdb_print_gvars.py
@@ -8,14 +8,16 @@ from optparse import OptionParser
 from pdbparse.pe import Sections
 from pdbparse.omap import Omap
 
+
 class DummyOmap(object):
+
     def remap(self, addr):
         return addr
+
 
 def cstring(str):
     return str.split(b'\0')[0]
 
-    
 
 def main(filename, base_address):
     pdb = pdbparse.parse(filename)
@@ -31,17 +33,17 @@ def main(filename, base_address):
 
     gsyms = pdb.STREAM_GSYM
 
-
     for sym in gsyms.globals:
         try:
             off = sym.offset
-            virt_base = sects[sym.segment-1].VirtualAddress
-            nm = cstring(sects[sym.segment-1].Name)
-            print ("%s,%#x,%d,%s" % (sym.name,imgbase+omap.remap(off+virt_base),sym.symtype,nm))
-        except IndexError  as e:
-            print ("Skipping %s, segment %d does not exist" % (sym.name,sym.segment-1), file=sys.stderr)
+            virt_base = sects[sym.segment - 1].VirtualAddress
+            nm = cstring(sects[sym.segment - 1].Name)
+            print("%s,%#x,%d,%s" % (sym.name, imgbase + omap.remap(off + virt_base), sym.symtype, nm))
+        except IndexError as e:
+            print("Skipping %s, segment %d does not exist" % (sym.name, sym.segment - 1), file = sys.stderr)
         except AttributeError as e:
             pass
+
 
 if __name__ == '__main__':
 

--- a/examples/pdb_print_tpi.py
+++ b/examples/pdb_print_tpi.py
@@ -5,7 +5,7 @@ import pdbparse
 
 ARCH_PTR_SIZE = 4
 
-ctype  = {
+ctype = {
     "T_32PINT4": "pointer to long",
     "T_32PRCHAR": "pointer to unsigned char",
     "T_32PUCHAR": "pointer to unsigned char",
@@ -59,50 +59,67 @@ base_type_size = {
     "T_32PLONG": 4,
 }
 
+
 def get_size(lf):
-    if isinstance(lf,str):
+    if isinstance(lf, str):
         return base_type_size[lf]
-    elif (lf.leaf_type == "LF_STRUCTURE" or
-          lf.leaf_type == "LF_ARRAY" or
-          lf.leaf_type == "LF_UNION"):
+    elif (lf.leaf_type == "LF_STRUCTURE" or lf.leaf_type == "LF_ARRAY" or lf.leaf_type == "LF_UNION"):
         return lf.size
     elif lf.leaf_type == "LF_POINTER":
         return ARCH_PTR_SIZE
     elif lf.leaf_type == "LF_MODIFIER":
         return get_size(lf.modified_type)
-    else: return -1
+    else:
+        return -1
+
 
 def get_tpname(lf):
     if isinstance(lf, str):
-        try: tpname = ctype[lf]
-        except KeyError: tpname = lf
-    elif lf.leaf_type == "LF_STRUCTURE": tpname = lf.name
-    elif lf.leaf_type == "LF_ENUM": tpname = lf.name
-    elif lf.leaf_type == "LF_UNION": tpname = lf.name
-    elif lf.leaf_type == "LF_POINTER": tpname = ptr_str(lf)
-    elif lf.leaf_type == "LF_PROCEDURE": tpname = proc_str(lf)
-    elif lf.leaf_type == "LF_MODIFIER": tpname = mod_str(lf)
-    elif lf.leaf_type == "LF_ARRAY": tpname = arr_str(lf)
-    elif lf.leaf_type == "LF_BITFIELD": tpname = bit_str(lf)
-    else: tpname = lf.leaf_type
+        try:
+            tpname = ctype[lf]
+        except KeyError:
+            tpname = lf
+    elif lf.leaf_type == "LF_STRUCTURE":
+        tpname = lf.name
+    elif lf.leaf_type == "LF_ENUM":
+        tpname = lf.name
+    elif lf.leaf_type == "LF_UNION":
+        tpname = lf.name
+    elif lf.leaf_type == "LF_POINTER":
+        tpname = ptr_str(lf)
+    elif lf.leaf_type == "LF_PROCEDURE":
+        tpname = proc_str(lf)
+    elif lf.leaf_type == "LF_MODIFIER":
+        tpname = mod_str(lf)
+    elif lf.leaf_type == "LF_ARRAY":
+        tpname = arr_str(lf)
+    elif lf.leaf_type == "LF_BITFIELD":
+        tpname = bit_str(lf)
+    else:
+        tpname = lf.leaf_type
     return tpname
+
 
 def bit_str(bitf):
     return "bitfield pos: %d len: %d [%s]" % (bitf.position, bitf.length, get_tpname(bitf.base_type))
 
+
 def arr_str(arr):
     tpname = get_tpname(arr.element_type)
-    count = arr.size / get_size(arr.element_type) 
+    count = arr.size / get_size(arr.element_type)
     return "array %s[%d]" % (tpname, count)
+
 
 def mod_str(mod):
     tpname = get_tpname(mod.modified_type)
-    modifiers = [ m for m in ["const","unaligned","volatile"] if mod.modifier[m]]
+    modifiers = [m for m in ["const", "unaligned", "volatile"] if mod.modifier[m]]
     return "%s %s" % (" ".join(modifiers), tpname)
+
 
 def ptr_str(ptr):
     tpname = get_tpname(ptr.utype)
     return "pointer to %s" % tpname
+
 
 def proc_str(proc):
     argstrs = []
@@ -110,31 +127,36 @@ def proc_str(proc):
         argstrs.append(get_tpname(a))
     return "function(%s)" % ", ".join(argstrs)
 
+
 def memb_str(memb):
     off = memb.offset
     tpname = get_tpname(memb.index)
     return "%#x: %s (%s)" % (off, memb.name, tpname)
 
+
 def struct_pretty_str(lf):
-    return (lf.name + (", %#x bytes\n    " % lf.size) + 
-            "\n    ".join(memb_str(s) for s in lf.fieldlist.substructs))
+    return (lf.name + (", %#x bytes\n    " % lf.size) + "\n    ".join(memb_str(s) for s in lf.fieldlist.substructs))
+
 
 def enum_pretty_str(enum):
     enumerated = []
     utypename = get_tpname(enum.utype)
     for e in enum.fieldlist.substructs:
         enumerated.append("%s = %d" % (e.name, e.enum_value))
-    return (enum.name + (" (%s)\n    " % utypename) + 
-            "\n    ".join(enumerated))
+    return (enum.name + (" (%s)\n    " % utypename) + "\n    ".join(enumerated))
+
 
 pdb = pdbparse.parse(sys.argv[1])
-structs = [ s for s in pdb.streams[2].types.values() if (s.leaf_type == "LF_STRUCTURE" or s.leaf_type == "LF_UNION") and not s.prop.fwdref ]
-enums = [ e for e in pdb.streams[2].types.values() if e.leaf_type == "LF_ENUM" and not e.prop.fwdref ]
+structs = [
+    s for s in pdb.streams[2].types.values()
+    if (s.leaf_type == "LF_STRUCTURE" or s.leaf_type == "LF_UNION") and not s.prop.fwdref
+]
+enums = [e for e in pdb.streams[2].types.values() if e.leaf_type == "LF_ENUM" and not e.prop.fwdref]
 
-print ("*******  Structures  *******")
+print("*******  Structures  *******")
 for s in structs:
-    print (struct_pretty_str(s))
+    print(struct_pretty_str(s))
 
-print ("******* Enumerations *******")
+print("******* Enumerations *******")
 for e in enums:
-    print (enum_pretty_str(e))
+    print(enum_pretty_str(e))

--- a/examples/symchk.py
+++ b/examples/symchk.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 ''' 
 Download debugging symbols from the Microsoft Symbol Server. 
 Can use as an input an executable file OR a GUID+Age and filename.
@@ -28,7 +27,7 @@ You can see an explanation of the URL format at:
 http://jimmers.info/pdb.html
 '''
 
-import sys,os
+import sys, os
 import os.path
 from pefile import PE
 from shutil import copyfileobj
@@ -49,110 +48,117 @@ except ImportError:
 SYM_URLS = ['http://msdl.microsoft.com/download/symbols']
 USER_AGENT = "Microsoft-Symbol-Server/6.11.0001.404"
 
+
 class PDBOpener(FancyURLopener):
     version = USER_AGENT
+
     def http_error_default(self, url, fp, errcode, errmsg, headers):
         if errcode == 404:
             raise HTTPError(url, errcode, errmsg, headers, fp)
         else:
             FancyURLopener.http_error_default(url, fp, errcode, errmsg, headers)
 
+
 lastprog = None
-def progress(blocks,blocksz,totalsz):
+
+
+def progress(blocks, blocksz, totalsz):
     global lastprog
     if lastprog is None:
-        print ("Connected. Downloading data...")
-    percent = int((100*(blocks*blocksz)/float(totalsz)))
-    if lastprog != percent and percent % 5 == 0: print ("%d%%" % percent)
+        print("Connected. Downloading data...")
+    percent = int((100 * (blocks * blocksz) / float(totalsz)))
+    if lastprog != percent and percent % 5 == 0: print("%d%%" % percent)
     lastprog = percent
     sys.stdout.flush()
 
-def download_file(guid,fname,path="",quiet=False):
+
+def download_file(guid, fname, path = "", quiet = False):
     ''' 
     Download the symbols specified by guid and filename. Note that 'guid'
     must be the GUID from the executable with the dashes removed *AND* the
     Age field appended. The resulting file will be saved to the path argument,
     which default to the current directory.
     '''
-    
+
     # A normal GUID is 32 bytes. With the age field appended
     # the GUID argument should therefore be longer to be valid.
-    # Exception: old-style PEs without a debug section use 
+    # Exception: old-style PEs without a debug section use
     # TimeDateStamp+SizeOfImage
     if len(guid) == 32:
-        print ("Warning: GUID is too short to be valid. Did you append the Age field?")
+        print("Warning: GUID is too short to be valid. Did you append the Age field?")
 
     for sym_url in SYM_URLS:
-        url = sym_url + "/%s/%s/" % (fname,guid)
+        url = sym_url + "/%s/%s/" % (fname, guid)
         opener = build_opener()
-        
+
         # Whatever extension the user has supplied it must be replaced with .pd_
-        tries = [ fname[:-1] + '_', fname ]
+        tries = [fname[:-1] + '_', fname]
 
         for t in tries:
-            if not quiet: print ("Trying %s" % (url+t))
-            outfile = os.path.join(path,t)
+            if not quiet: print("Trying %s" % (url + t))
+            outfile = os.path.join(path, t)
             try:
                 hook = None if quiet else progress
-                PDBOpener().retrieve(url+t, outfile, reporthook=hook)
+                PDBOpener().retrieve(url + t, outfile, reporthook = hook)
                 if not quiet:
-                    print ()
-                    print ("Saved symbols to %s" % (outfile))
+                    print()
+                    print("Saved symbols to %s" % (outfile))
                 return outfile
             except HTTPError as e:
                 if not quiet:
-                    print ("HTTP error %u" % (e.code))
+                    print("HTTP error %u" % (e.code))
     return None
+
 
 def handle_pe(pe_file):
     dbgdata, tp = get_pe_debug_data(pe_file)
     if tp == "IMAGE_DEBUG_TYPE_CODEVIEW":
         # XP+
         if dbgdata[:4] == b"RSDS":
-            (guid,filename) = get_rsds(dbgdata)
+            (guid, filename) = get_rsds(dbgdata)
         elif dbgdata[:4] == b"NB10":
-            (guid,filename) = get_nb10(dbgdata)
+            (guid, filename) = get_nb10(dbgdata)
         else:
-            print ("ERR: CodeView section not NB10 or RSDS")
+            print("ERR: CodeView section not NB10 or RSDS")
             return
         guid = guid.upper()
-        saved_file = download_file(guid,filename)
+        saved_file = download_file(guid, filename)
     elif tp == "IMAGE_DEBUG_TYPE_MISC":
         # Win2k
         # Get the .dbg file
         guid = get_pe_guid(pe_file)
         guid = guid.upper()
         filename = get_dbg_fname(dbgdata)
-        saved_file = download_file(guid,filename)
+        saved_file = download_file(guid, filename)
 
         # Extract it if it's compressed
         # Note: requires cabextract!
         if saved_file.endswith("_"):
             os.system("cabextract %s" % saved_file)
-            saved_file = saved_file.replace('.db_','.dbg')
+            saved_file = saved_file.replace('.db_', '.dbg')
 
         from pdbparse.dbgold import DbgFile
         dbgfile = DbgFile.parse_stream(open(saved_file, 'rb'))
-        cv_entry = [ d for d in dbgfile.IMAGE_DEBUG_DIRECTORY
-                       if d.Type == "IMAGE_DEBUG_TYPE_CODEVIEW"][0]
+        cv_entry = [d for d in dbgfile.IMAGE_DEBUG_DIRECTORY if d.Type == "IMAGE_DEBUG_TYPE_CODEVIEW"][0]
         if cv_entry.Data[:4] == b"NB09":
             return
         elif cv_entry.Data[:4] == b"NB10":
-            (guid,filename) = get_nb10(cv_entry.Data)
-            
+            (guid, filename) = get_nb10(cv_entry.Data)
+
             guid = guid.upper()
-            saved_file = download_file(guid,filename)
+            saved_file = download_file(guid, filename)
         else:
-            print ("WARN: DBG file received from symbol server has unknown CodeView section")
+            print("WARN: DBG file received from symbol server has unknown CodeView section")
             return
     else:
-        print ("Unknown type:",tp)
+        print("Unknown type:", tp)
         return
 
     if saved_file != None and saved_file.endswith("_"):
         os.system("cabextract %s" % saved_file)
 
-def get_pe_from_pe(filename, symname=None):
+
+def get_pe_from_pe(filename, symname = None):
     guid = get_pe_guid(filename)
     if symname is None:
         symname = os.path.basename(filename)
@@ -160,25 +166,30 @@ def get_pe_from_pe(filename, symname=None):
     if saved_file and saved_file.endswith("_"):
         os.system("cabextract %s" % saved_file)
 
+
 def main():
     global SYM_URLS
     from optparse import OptionParser
 
     parser = OptionParser()
-    parser.add_option('-e', '--executable', dest='exe',
-                      help='download symbols for an executable')
-    parser.add_option('-p', '--pefile', dest='pe',
-                      help='download clean copy of an executable')
-    parser.add_option('-g', '--guid', dest='guid',
-                      help='use GUID to download symbols [Note: requires -s]')
-    parser.add_option('-s', '--symbols', dest='symfile', metavar='FILENAME',
-                      help='use FILENAME to download symbols [Note: requires -g]')
-    parser.add_option('-u', '--url', dest='url', metavar='URL',
-                      help=('use * separated URLs to search for symbols, e.g. ' +
-                            '"http://foo.com*http://bar.com". You may also set ' +
-                            'the SYMPATH environment variable'))
+    parser.add_option('-e', '--executable', dest = 'exe', help = 'download symbols for an executable')
+    parser.add_option('-p', '--pefile', dest = 'pe', help = 'download clean copy of an executable')
+    parser.add_option('-g', '--guid', dest = 'guid', help = 'use GUID to download symbols [Note: requires -s]')
+    parser.add_option(
+        '-s',
+        '--symbols',
+        dest = 'symfile',
+        metavar = 'FILENAME',
+        help = 'use FILENAME to download symbols [Note: requires -g]')
+    parser.add_option(
+        '-u',
+        '--url',
+        dest = 'url',
+        metavar = 'URL',
+        help = ('use * separated URLs to search for symbols, e.g. ' +
+                '"http://foo.com*http://bar.com". You may also set ' + 'the SYMPATH environment variable'))
 
-    opts,args = parser.parse_args()
+    opts, args = parser.parse_args()
 
     if opts.url:
         SYM_URLS = opts.url.split('*')
@@ -188,17 +199,19 @@ def main():
     if opts.exe:
         handle_pe(opts.exe)
     if opts.pe:
-        get_pe_from_pe(opts.pe, symname=opts.symfile)
+        get_pe_from_pe(opts.pe, symname = opts.symfile)
     if opts.guid and opts.symfile:
         saved_file = download_file(opts.guid, opts.symfile)
         if saved_file is not None:
             if saved_file.endswith("_"):
                 os.system("cabextract %s" % saved_file)
-    
+
     if not (opts.exe or opts.guid or opts.symfile or opts.pe) and args:
-        for a in args: handle_pe(a)
+        for a in args:
+            handle_pe(a)
     elif not (opts.exe or opts.guid or opts.symfile or opts.pe) and not args:
         parser.error("Must supply a PE file or specify by GUID")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/tpi_closure.py
+++ b/examples/tpi_closure.py
@@ -10,127 +10,185 @@ lists = {
     #('_RTL_CRITICAL_SECTION_DEBUG', 'ProcessLocksList'): ,
     #_KPROCESS -> _SINGLE_LIST_ENTRY; # SwapListEntry
     #_KTHREAD -> _SINGLE_LIST_ENTRY; # SwapListEntry
-    ('_CM_KEY_BODY', 'KeyBodyList'): '_CM_KEY_BODY',
-    ('_CM_KEY_CONTROL_BLOCK', 'FreeListEntry'): '_CM_KEY_CONTROL_BLOCK',
-    ('_CM_KEY_CONTROL_BLOCK', 'KeyBodyListHead'): '_CM_KEY_BODY',
-    ('_CM_KEY_SECURITY_CACHE', 'List'): '_CM_KEY_SECURITY_CACHE',
-    ('_CM_NOTIFY_BLOCK', 'HiveList'): '_CM_NOTIFY_BLOCK',
-    ('_CM_NOTIFY_BLOCK', 'PostList'): '_CM_POST_BLOCK',
-    ('_CM_POST_BLOCK', 'CancelPostList'): '_CM_POST_BLOCK',
-    ('_CM_POST_BLOCK', 'NotifyList'): '_CM_POST_BLOCK',
-    ('_CM_POST_BLOCK', 'ThreadList'): '_CM_POST_BLOCK',
-    ('_CM_POST_KEY_BODY', 'KeyBodyList'): '_CM_POST_KEY_BODY',
-    ('_DISPATCHER_HEADER', 'WaitListHead'): '_KWAIT_BLOCK',
-    ('_EJOB', 'JobLinks'): '_EPROCESS',
-    ('_EJOB', 'JobSetLinks'): '_EJOB',
-    ('_EJOB', 'ProcessListHead'): '_EPROCESS',
-    ('_EPROCESS', 'ActiveProcessLinks'): '_EPROCESS',
-    ('_EPROCESS', 'JobLinks'): '_EPROCESS',
-    ('_EPROCESS', 'MmProcessLinks'): '_EPROCESS',
-    ('_EPROCESS', 'SessionProcessLinks'): '_EPROCESS',
-    ('_EPROCESS', 'ThreadListHead'): '_ETHREAD',
-    ('_EPROCESS_QUOTA_BLOCK', 'QuotaList'): '_EPROCESS_QUOTA_BLOCK',
-    ('_ERESOURCE', 'SystemResourcesList'): '_ERESOURCE',
-    ('_ETHREAD', 'ActiveTimerListHead'): '_ETIMER',
-    ('_ETHREAD', 'IrpList'): '_IRP',
-    ('_ETHREAD', 'KeyedWaitChain'): '_ETHREAD',
-    ('_ETHREAD', 'LpcReplyChain'): '_ETHREAD',
-    ('_ETHREAD', 'PostBlockList'): '_CM_POST_BLOCK',
-    ('_ETHREAD', 'ThreadListEntry'): '_ETHREAD',
-    ('_ETIMER', 'ActiveTimerListEntry'): '_ETIMER',
-    ('_ETIMER', 'WakeTimerListEntry'): '_ETIMER',
-    ('_HANDLE_TABLE', 'HandleTableList'): '_HANDLE_TABLE',
-    ('_IO_TIMER', 'TimerList'): '_IO_TIMER',
-    ('_IRP', 'ThreadListEntry'): '_IRP',
-    ('_KAPC', 'ApcListEntry'): '_KAPC',
-    ('_KDEVICE_QUEUE', 'DeviceListHead'): '_KDEVICE_QUEUE_ENTRY',
-    ('_KDPC', 'DpcListEntry'): '_KDPC',
-    ('_KMUTANT', 'MutantListEntry'): '_KMUTANT',
-    ('_KPROCESS', 'ProcessListEntry'): '_KPROCESS',
-    ('_KPROCESS', 'ProfileListHead'): '_KPROFILE',
-    ('_KPROCESS', 'ReadyListHead'): '_KTHREAD',
-    ('_KPROCESS', 'ThreadListHead'): '_KTHREAD',
-    ('_KPROFILE', 'ProfileListEntry'): '_KPROFILE',
-    ('_KQUEUE', 'EntryListHead'): '_KQUEUE',
-    ('_KQUEUE', 'ThreadListHead'): '_KTHREAD',
-    ('_KTHREAD', 'MutantListHead'): '_KMUTANT',
-    ('_KTHREAD', 'QueueListEntry'): '_KTHREAD',
-    ('_KTHREAD', 'ThreadListEntry'): '_KTHREAD',
-    ('_KTHREAD', 'WaitListEntry'): '_KTHREAD',
-    ('_KTIMER', 'TimerListEntry'): '_KTIMER',
-    ('_KWAIT_BLOCK', 'WaitListEntry'): '_KWAIT_BLOCK',
-    ('_MMSUPPORT', 'WorkingSetExpansionLinks'): '_MMSUPPORT',
-    ('_PEB_LDR_DATA', 'InInitializationOrderModuleList'): '_PEB_LDR_DATA',
-    ('_PEB_LDR_DATA', 'InLoadOrderModuleList'): '_PEB_LDR_DATA',
-    ('_PEB_LDR_DATA', 'InMemoryOrderModuleList'): '_PEB_LDR_DATA',
+    ('_CM_KEY_BODY', 'KeyBodyList'):
+    '_CM_KEY_BODY',
+    ('_CM_KEY_CONTROL_BLOCK', 'FreeListEntry'):
+    '_CM_KEY_CONTROL_BLOCK',
+    ('_CM_KEY_CONTROL_BLOCK', 'KeyBodyListHead'):
+    '_CM_KEY_BODY',
+    ('_CM_KEY_SECURITY_CACHE', 'List'):
+    '_CM_KEY_SECURITY_CACHE',
+    ('_CM_NOTIFY_BLOCK', 'HiveList'):
+    '_CM_NOTIFY_BLOCK',
+    ('_CM_NOTIFY_BLOCK', 'PostList'):
+    '_CM_POST_BLOCK',
+    ('_CM_POST_BLOCK', 'CancelPostList'):
+    '_CM_POST_BLOCK',
+    ('_CM_POST_BLOCK', 'NotifyList'):
+    '_CM_POST_BLOCK',
+    ('_CM_POST_BLOCK', 'ThreadList'):
+    '_CM_POST_BLOCK',
+    ('_CM_POST_KEY_BODY', 'KeyBodyList'):
+    '_CM_POST_KEY_BODY',
+    ('_DISPATCHER_HEADER', 'WaitListHead'):
+    '_KWAIT_BLOCK',
+    ('_EJOB', 'JobLinks'):
+    '_EPROCESS',
+    ('_EJOB', 'JobSetLinks'):
+    '_EJOB',
+    ('_EJOB', 'ProcessListHead'):
+    '_EPROCESS',
+    ('_EPROCESS', 'ActiveProcessLinks'):
+    '_EPROCESS',
+    ('_EPROCESS', 'JobLinks'):
+    '_EPROCESS',
+    ('_EPROCESS', 'MmProcessLinks'):
+    '_EPROCESS',
+    ('_EPROCESS', 'SessionProcessLinks'):
+    '_EPROCESS',
+    ('_EPROCESS', 'ThreadListHead'):
+    '_ETHREAD',
+    ('_EPROCESS_QUOTA_BLOCK', 'QuotaList'):
+    '_EPROCESS_QUOTA_BLOCK',
+    ('_ERESOURCE', 'SystemResourcesList'):
+    '_ERESOURCE',
+    ('_ETHREAD', 'ActiveTimerListHead'):
+    '_ETIMER',
+    ('_ETHREAD', 'IrpList'):
+    '_IRP',
+    ('_ETHREAD', 'KeyedWaitChain'):
+    '_ETHREAD',
+    ('_ETHREAD', 'LpcReplyChain'):
+    '_ETHREAD',
+    ('_ETHREAD', 'PostBlockList'):
+    '_CM_POST_BLOCK',
+    ('_ETHREAD', 'ThreadListEntry'):
+    '_ETHREAD',
+    ('_ETIMER', 'ActiveTimerListEntry'):
+    '_ETIMER',
+    ('_ETIMER', 'WakeTimerListEntry'):
+    '_ETIMER',
+    ('_HANDLE_TABLE', 'HandleTableList'):
+    '_HANDLE_TABLE',
+    ('_IO_TIMER', 'TimerList'):
+    '_IO_TIMER',
+    ('_IRP', 'ThreadListEntry'):
+    '_IRP',
+    ('_KAPC', 'ApcListEntry'):
+    '_KAPC',
+    ('_KDEVICE_QUEUE', 'DeviceListHead'):
+    '_KDEVICE_QUEUE_ENTRY',
+    ('_KDPC', 'DpcListEntry'):
+    '_KDPC',
+    ('_KMUTANT', 'MutantListEntry'):
+    '_KMUTANT',
+    ('_KPROCESS', 'ProcessListEntry'):
+    '_KPROCESS',
+    ('_KPROCESS', 'ProfileListHead'):
+    '_KPROFILE',
+    ('_KPROCESS', 'ReadyListHead'):
+    '_KTHREAD',
+    ('_KPROCESS', 'ThreadListHead'):
+    '_KTHREAD',
+    ('_KPROFILE', 'ProfileListEntry'):
+    '_KPROFILE',
+    ('_KQUEUE', 'EntryListHead'):
+    '_KQUEUE',
+    ('_KQUEUE', 'ThreadListHead'):
+    '_KTHREAD',
+    ('_KTHREAD', 'MutantListHead'):
+    '_KMUTANT',
+    ('_KTHREAD', 'QueueListEntry'):
+    '_KTHREAD',
+    ('_KTHREAD', 'ThreadListEntry'):
+    '_KTHREAD',
+    ('_KTHREAD', 'WaitListEntry'):
+    '_KTHREAD',
+    ('_KTIMER', 'TimerListEntry'):
+    '_KTIMER',
+    ('_KWAIT_BLOCK', 'WaitListEntry'):
+    '_KWAIT_BLOCK',
+    ('_MMSUPPORT', 'WorkingSetExpansionLinks'):
+    '_MMSUPPORT',
+    ('_PEB_LDR_DATA', 'InInitializationOrderModuleList'):
+    '_PEB_LDR_DATA',
+    ('_PEB_LDR_DATA', 'InLoadOrderModuleList'):
+    '_PEB_LDR_DATA',
+    ('_PEB_LDR_DATA', 'InMemoryOrderModuleList'):
+    '_PEB_LDR_DATA',
 }
 
 traversed = set()
 
-def print_closure(s, nodes=False, comments=False):
+
+def print_closure(s, nodes = False, comments = False):
     global structs
     global traversed
     traversed.add(s)
-    
-    if isinstance(s.fieldlist,str):
+
+    if isinstance(s.fieldlist, str):
         return
 
     if nodes:
-        print ('    %s_%d [label="{ %s | Index: %d \\n Size: %d \\n Members: %d }", shape=record];' % (s.name, s.tpi_idx,
-            s.name, s.tpi_idx, s.size, s.count))
+        print('    %s_%d [label="{ %s | Index: %d \\n Size: %d \\n Members: %d }", shape=record];' %
+              (s.name, s.tpi_idx, s.name, s.tpi_idx, s.size, s.count))
 
     for u in s.fieldlist.substructs:
         if u.leaf_type == "LF_MEMBER":
-            if isinstance(u.index,str): continue
+            if isinstance(u.index, str): continue
             if u.index.leaf_type == "LF_STRUCTURE":
-                if u.index.name == '_LIST_ENTRY' and (s.name,u.name) in lists:
-                    list_element_type = structs[lists[(s.name,u.name)]]
+                if u.index.name == '_LIST_ENTRY' and (s.name, u.name) in lists:
+                    list_element_type = structs[lists[(s.name, u.name)]]
                     if nodes:
-                        print ('    %s_%d -> %s_%d [style=dashed,color=forestgreen]; %s' % (s.name, s.tpi_idx, list_element_type.name, list_element_type.tpi_idx,
-                                                                      "//" + u.name if comments else ""))
+                        print('    %s_%d -> %s_%d [style=dashed,color=forestgreen]; %s' %
+                              (s.name, s.tpi_idx, list_element_type.name, list_element_type.tpi_idx,
+                               "//" + u.name if comments else ""))
                     else:
-                        print ('    %s -> %s [style=dashed,color=forestgreen]; %s' % (s.name, list_element_type.name,
-                                                                   "//" + u.name if comments else ""))
+                        print('    %s -> %s [style=dashed,color=forestgreen]; %s' % (s.name, list_element_type.name,
+                                                                                     "//" + u.name if comments else ""))
                     next_type = list_element_type
                 else:
                     if nodes:
-                        print ('    %s_%d -> %s_%d [color=blue]; %s' % (s.name, s.tpi_idx, u.index.name, u.index.tpi_idx,
-                                                          "//" + u.name if comments else ""))
+                        print('    %s_%d -> %s_%d [color=blue]; %s' % (s.name, s.tpi_idx, u.index.name, u.index.tpi_idx,
+                                                                       "//" + u.name if comments else ""))
                     else:
-                        print ('    %s -> %s [color=blue]; %s' % (s.name, u.index.name,
-                                                    "//" + u.name if comments else ""))
+                        print(
+                            '    %s -> %s [color=blue]; %s' % (s.name, u.index.name, "//" + u.name if comments else ""))
                     next_type = u.index
 
                 if not next_type in traversed:
                     print_closure(next_type, nodes)
-            elif (u.index.leaf_type == "LF_POINTER" and
-                  not isinstance(u.index.utype,str) and
-                  u.index.utype.leaf_type == "LF_STRUCTURE"):
+            elif (u.index.leaf_type == "LF_POINTER" and not isinstance(u.index.utype, str)
+                  and u.index.utype.leaf_type == "LF_STRUCTURE"):
                 if nodes:
-                    print ('    %s_%d -> %s_%d [style=dashed,color=red]; %s' % (s.name, s.tpi_idx, u.index.utype.name, u.index.utype.tpi_idx,
-                                                                  "//" + u.name if comments else ""))
+                    print('    %s_%d -> %s_%d [style=dashed,color=red]; %s' %
+                          (s.name, s.tpi_idx, u.index.utype.name, u.index.utype.tpi_idx,
+                           "//" + u.name if comments else ""))
                 else:
-                    print ('    %s -> %s [style=dashed,color=red]; %s' % (s.name, u.index.utype.name,
-                                                                  "//" + u.name if comments else ""))
+                    print('    %s -> %s [style=dashed,color=red]; %s' % (s.name, u.index.utype.name,
+                                                                         "//" + u.name if comments else ""))
                 if not u.index.utype in traversed:
                     print_closure(u.index.utype, nodes)
 
+
 parser = OptionParser()
-parser.add_option("-n", "--nodes",
-                  action="store_true", dest="nodes", default=False,
-                  help="include detailed nodes in graph")
-parser.add_option("-c", "--comments",
-                  action="store_true", dest="comments", default=False,
-                  help="append field names as comments")
+parser.add_option(
+    "-n", "--nodes", action = "store_true", dest = "nodes", default = False, help = "include detailed nodes in graph")
+parser.add_option(
+    "-c",
+    "--comments",
+    action = "store_true",
+    dest = "comments",
+    default = False,
+    help = "append field names as comments")
 (opts, args) = parser.parse_args()
 if len(args) < 2:
     parser.error("Both PDB and base type name are required.")
-
 
 pdb = pdbparse.parse(args[0])
 structs = pdb.streams[2].structures
 base_type = structs[args[1]]
 
-print ("digraph %s {" % basename(args[0]).split('.')[0])
+print("digraph %s {" % basename(args[0]).split('.')[0])
 print_closure(base_type, opts.nodes, opts.comments)
-print ("}")
+print("}")

--- a/examples/tpi_print_construct.py
+++ b/examples/tpi_print_construct.py
@@ -44,32 +44,31 @@ base_type_size = {
     "T_UQUAD": 8,
     "T_USHORT": 2,
 }
+
+
 def get_size(lf):
-    if isinstance(lf,str):
+    if isinstance(lf, str):
         return base_type_size[lf]
-    elif (lf.leaf_type == "LF_STRUCTURE" or
-          lf.leaf_type == "LF_ARRAY" or
-          lf.leaf_type == "LF_UNION"):
+    elif (lf.leaf_type == "LF_STRUCTURE" or lf.leaf_type == "LF_ARRAY" or lf.leaf_type == "LF_UNION"):
         return lf.size
     elif lf.leaf_type == "LF_POINTER":
         return ARCH_PTR_SIZE
     elif lf.leaf_type == "LF_MODIFIER":
         return get_size(lf.modified_type)
-    else: return -1
+    else:
+        return -1
 
 
-def construct(lf, name=None):
+def construct(lf, name = None):
     if isinstance(lf, str):
         return '%s' % (con_base_type[lf] % name)
     elif lf.leaf_type == 'LF_POINTER':
         if hasattr(lf.utype, 'name'):
             return 'ULInt32("%s-%s")' % (name or "ptr", lf.utype.name)
         else:
-            return 'ULInt32("%s-%s_%s")' % (name or "ptr", lf.utype.leaf_type,
-                lf.utype.tpi_idx)
+            return 'ULInt32("%s-%s_%s")' % (name or "ptr", lf.utype.leaf_type, lf.utype.tpi_idx)
     elif lf.leaf_type == 'LF_STRUCTURE':
-        return 'Struct("%s", # %s\n%s\n)' % (name or lf.name, lf.name,
-            construct(lf.fieldlist))
+        return 'Struct("%s", # %s\n%s\n)' % (name or lf.name, lf.name, construct(lf.fieldlist))
     elif lf.leaf_type == 'LF_FIELDLIST':
         return ',\n'.join(construct(l) for l in lf.substructs)
     elif lf.leaf_type == "LF_MEMBER":
@@ -85,9 +84,9 @@ def construct(lf, name=None):
     else:
         return "Unimplemented %s" % lf.leaf_type
 
+
 tpi_stream = tpi.parse_stream(open(sys.argv[1]))
-structs = [ t for t in tpi_stream.types.values() 
-                if t.leaf_type == 'LF_STRUCTURE' and not t.prop.fwdref ]
+structs = [t for t in tpi_stream.types.values() if t.leaf_type == 'LF_STRUCTURE' and not t.prop.fwdref]
 
 for s in structs:
     if s.name == "_EPROCESS": print(construct(s))

--- a/pdbparse/__init__.py
+++ b/pdbparse/__init__.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
 
-from struct import unpack,calcsize
+from struct import unpack, calcsize
 
-PDB_STREAM_ROOT   = 0 # PDB root directory
-PDB_STREAM_PDB    = 1 # PDB stream info
-PDB_STREAM_TPI    = 2 # type info
-PDB_STREAM_DBI    = 3 # debug info
+PDB_STREAM_ROOT = 0  # PDB root directory
+PDB_STREAM_PDB = 1  # PDB stream info
+PDB_STREAM_TPI = 2  # type info
+PDB_STREAM_DBI = 3  # debug info
 
 _PDB2_SIGNATURE = b"Microsoft C/C++ program database 2.00\r\n\032JG\0\0"
 _PDB2_SIGNATURE_LEN = len(_PDB2_SIGNATURE)
@@ -18,6 +18,7 @@ _PDB7_SIGNATURE_LEN = len(_PDB7_SIGNATURE)
 _PDB7_FMT = "<%dsIIIII" % _PDB7_SIGNATURE_LEN
 _PDB7_FMT_SIZE = calcsize(_PDB7_FMT)
 
+
 # Internal method to calculate the number of pages required
 # to store a stream of size "length", given a page size of
 # "pagesize"
@@ -26,51 +27,59 @@ def _pages(length, pagesize):
     if (length % pagesize): num_pages += 1
     return num_pages
 
+
 class StreamFile:
-    def __init__(self, fp, pages, size=-1, page_size=0x1000):
+
+    def __init__(self, fp, pages, size = -1, page_size = 0x1000):
         self.fp = fp
         self.pages = pages
         self.page_size = page_size
-        if size == -1: self.end = len(pages)*page_size
+        if size == -1: self.end = len(pages) * page_size
         else: self.end = size
         self.pos = 0
-    def read(self, size=-1):
+
+    def read(self, size = -1):
         if size == -1:
             pn_start, off_start = self._get_page(self.pos)
             pdata = self._read_pages(self.pages[pn_start:])
             self.pos = self.end
-            return pdata[off_start:self.end-off_start]
+            return pdata[off_start:self.end - off_start]
         else:
             pn_start, off_start = self._get_page(self.pos)
             pn_end, off_end = self._get_page(self.pos + size)
-            pdata = self._read_pages(self.pages[pn_start:pn_end+1])
+            pdata = self._read_pages(self.pages[pn_start:pn_end + 1])
             self.pos += size
 
             return pdata[off_start:-(self.page_size - off_end)]
-    def seek(self, offset, whence=0):
+
+    def seek(self, offset, whence = 0):
         if whence == 0:
             self.pos = offset
         elif whence == 1:
             self.pos += offset
         elif whence == 2:
             self.pos = self.end + offset
-        
+
         if self.pos < 0: self.pos = 0
         if self.pos > self.end: self.pos = self.end
+
     def tell(self):
         return self.pos
+
     def close(self):
         self.fp.close()
 
     # Private helper methods
     def _get_page(self, offset):
         return (offset // self.page_size, offset % self.page_size)
+
     def _read_pages(self, pages):
         s = b""
         for pn in pages:
-           self.fp.seek(pn*self.page_size)
-           s += self.fp.read(self.page_size)
+            self.fp.seek(pn * self.page_size)
+            s += self.fp.read(self.page_size)
         return s
+
 
 class PDBStream:
     """Base class for PDB stream types.
@@ -83,44 +92,61 @@ class PDBStream:
     The constructor signature here is valid for all subclasses.
 
     """
+
     def _get_data(self):
         pos = self.stream_file.tell()
         self.stream_file.seek(0)
         data = self.stream_file.read()
         self.stream_file.seek(pos)
         return data
-    data = property(fget=_get_data)
 
-    def __init__(self, fp, pages, index, size=-1, page_size=0x1000, fast_load=False, parent=None):
+    data = property(fget = _get_data)
+
+    def __init__(self, fp, pages, index, size = -1, page_size = 0x1000, fast_load = False, parent = None):
         self.fp = fp
         self.fast_load = fast_load
         self.parent = parent
         self.pages = pages
         self.index = index
         self.page_size = page_size
-        if size == -1: self.size = len(pages)*page_size
+        if size == -1: self.size = len(pages) * page_size
         else: self.size = size
-        self.stream_file = StreamFile(self.fp, pages, size=size, page_size=page_size)
+        self.stream_file = StreamFile(self.fp, pages, size = size, page_size = page_size)
 
     def reload(self):
         """Convenience method. Reloads a PDBStream. May return a more specialized type."""
         try:
             pdb_cls = self.parent._stream_map[self.index]
-        except (KeyError,AttributeError) as e:
+        except (KeyError, AttributeError) as e:
             pdb_cls = PDBStream
-        return pdb_cls(self.fp, self.pages, self.index, size=self.size,
-                page_size=self.page_size, fast_load=self.fast_load,
-                parent=self.parent)
+        return pdb_cls(
+            self.fp,
+            self.pages,
+            self.index,
+            size = self.size,
+            page_size = self.page_size,
+            fast_load = self.fast_load,
+            parent = self.parent)
+
 
 class ParsedPDBStream(PDBStream):
-    def __init__(self, fp, pages, index=PDB_STREAM_PDB, size=-1,
-            page_size=0x1000, fast_load=False, parent=None):
-        PDBStream.__init__(self, fp, pages, index, size=size, page_size=page_size, fast_load=fast_load, parent=parent)
+
+    def __init__(self,
+                 fp,
+                 pages,
+                 index = PDB_STREAM_PDB,
+                 size = -1,
+                 page_size = 0x1000,
+                 fast_load = False,
+                 parent = None):
+        PDBStream.__init__(
+            self, fp, pages, index, size = size, page_size = page_size, fast_load = fast_load, parent = parent)
         if fast_load: return
         else: self.load()
 
     def load(self):
         pass
+
 
 class PDB7RootStream(PDBStream):
     """Class representing the root stream of a PDB file.
@@ -129,42 +155,42 @@ class PDB7RootStream(PDBStream):
     describing each stream in the "streams" member of this class.
 
     """
-    def __init__(self, fp, pages, index=PDB_STREAM_ROOT, size=-1,
-            page_size=0x1000, fast_load=False):
-        PDBStream.__init__(self, fp, pages, index, size=size, page_size=page_size)
+
+    def __init__(self, fp, pages, index = PDB_STREAM_ROOT, size = -1, page_size = 0x1000, fast_load = False):
+        PDBStream.__init__(self, fp, pages, index, size = size, page_size = page_size)
 
         data = self.data
-        
-        (self.num_streams,) = unpack("<I", data[:4])
-        
+
+        (self.num_streams, ) = unpack("<I", data[:4])
+
         # num_streams dwords giving stream sizes
         rs = data[4:]
         sizes = []
-        for i in range(0,self.num_streams*4,4):
-            (stream_size,) = unpack("<I",rs[i:i+4])
+        for i in range(0, self.num_streams * 4, 4):
+            (stream_size, ) = unpack("<I", rs[i:i + 4])
             # Seen in some recent symbols. Not sure what the difference between this
             # and stream_size == 0 is.
             if stream_size == 0xffffffff:
                 stream_size = 0
             sizes.append(stream_size)
-        
+
         # Next comes a list of the pages that make up each stream
-        rs = rs[self.num_streams*4:]
+        rs = rs[self.num_streams * 4:]
         page_lists = []
         pos = 0
         for i in range(self.num_streams):
             num_pages = _pages(sizes[i], self.page_size)
 
             if num_pages != 0:
-                pages = unpack("<" + ("%sI" % num_pages),
-                               rs[pos:pos+(num_pages*4)])
+                pages = unpack("<" + ("%sI" % num_pages), rs[pos:pos + (num_pages * 4)])
                 page_lists.append(pages)
-                pos += num_pages*4
+                pos += num_pages * 4
             else:
                 page_lists.append(())
 
         # use list() to make it compatible with python 3
         self.streams = list(zip(sizes, page_lists))
+
 
 class PDB2RootStream(PDBStream):
     """Class representing the root stream of a PDBv2 file.
@@ -173,39 +199,40 @@ class PDB2RootStream(PDBStream):
     describing each stream in the "streams" member of this class.
 
     """
-    def __init__(self, fp, pages, index=PDB_STREAM_ROOT, size=-1,
-            page_size=0x1000, fast_load=False):
-        PDBStream.__init__(self, fp, pages, index, size=size, page_size=page_size)
+
+    def __init__(self, fp, pages, index = PDB_STREAM_ROOT, size = -1, page_size = 0x1000, fast_load = False):
+        PDBStream.__init__(self, fp, pages, index, size = size, page_size = page_size)
         data = self.data
-        
+
         (self.num_streams, reserved) = unpack("<HH", data[:4])
-        
-        # num_streams 
+
+        # num_streams
         rs = data[4:]
         sizes = []
-        for i in range(0,self.num_streams*8,8):
-            (stream_size,ptr_reserved) = unpack("<II",rs[i:i+8])
+        for i in range(0, self.num_streams * 8, 8):
+            (stream_size, ptr_reserved) = unpack("<II", rs[i:i + 8])
             sizes.append(stream_size)
-        
+
         # Next comes a list of the pages that make up each stream
-        rs = rs[self.num_streams*8:]
+        rs = rs[self.num_streams * 8:]
         page_lists = []
         pos = 0
         for i in range(self.num_streams):
             num_pages = _pages(sizes[i], self.page_size)
 
             if num_pages != 0:
-                pages = unpack("<" + ("%dH" % num_pages),
-                               rs[pos:pos+(num_pages*2)])
+                pages = unpack("<" + ("%dH" % num_pages), rs[pos:pos + (num_pages * 2)])
                 page_lists.append(pages)
-                pos += num_pages*2
+                pos += num_pages * 2
             else:
                 page_lists.append(())
-        
+
         # use list() to make it compatible with python 3
         self.streams = list(zip(sizes, page_lists))
 
+
 class PDBInfoStream(ParsedPDBStream):
+
     def load(self):
         from pdbparse import info
         from datetime import datetime
@@ -218,25 +245,30 @@ class PDBInfoStream(ParsedPDBStream):
         self.names = inf.names
         del inf
 
+
 class PDBTypeStream(ParsedPDBStream):
-    def load(self,unnamed_hack=True,elim_fwdrefs=True):
+
+    def load(self, unnamed_hack = True, elim_fwdrefs = True):
         from pdbparse import tpi
-        tpis = tpi.parse_stream(self.stream_file,unnamed_hack,elim_fwdrefs)
+        tpis = tpi.parse_stream(self.stream_file, unnamed_hack, elim_fwdrefs)
         self.header = tpis.TPIHeader
         self.num_types = self.header.ti_max - self.header.ti_min
         self.types = tpis.types
-        self.structures = dict((s.name, s) for s in tpis.types.values()
-            if s.leaf_type == "LF_STRUCTURE" or s.leaf_type == "LF_STRUCTURE_ST")
+        self.structures = dict((s.name, s)
+                               for s in tpis.types.values()
+                               if s.leaf_type == "LF_STRUCTURE" or s.leaf_type == "LF_STRUCTURE_ST")
         del tpis
 
+
 class PDBDebugStream(ParsedPDBStream):
+
     def load(self):
-        from pdbparse import dbi 
+        from pdbparse import dbi
         debug = dbi.parse_stream(self.stream_file)
 
         self.DBIHeader = debug.DBIHeader
         self.DBIExHeaders = debug.DBIExHeaders
-        self.DBIDbgHeader = debug.DBIDbgHeader   
+        self.DBIDbgHeader = debug.DBIDbgHeader
         self.modules = debug.modules
         self.files = debug.files
 
@@ -250,17 +282,19 @@ class PDBDebugStream(ParsedPDBStream):
             if debug.DBIDbgHeader.snSectionHdr != -1:
                 self.parent.add_supported_stream("STREAM_SECT_HDR", debug.DBIDbgHeader.snSectionHdr, PDBSectionStream)
             if debug.DBIDbgHeader.snSectionHdrOrig != -1:
-                self.parent.add_supported_stream("STREAM_SECT_HDR_ORIG", debug.DBIDbgHeader.snSectionHdrOrig, PDBSectionStream)
+                self.parent.add_supported_stream("STREAM_SECT_HDR_ORIG", debug.DBIDbgHeader.snSectionHdrOrig,
+                                                 PDBSectionStream)
             if debug.DBIDbgHeader.snOmapToSrc != -1:
                 self.parent.add_supported_stream("STREAM_OMAP_TO_SRC", debug.DBIDbgHeader.snOmapToSrc, PDBOmapStream)
             if debug.DBIDbgHeader.snOmapFromSrc != -1:
-                self.parent.add_supported_stream("STREAM_OMAP_FROM_SRC", debug.DBIDbgHeader.snOmapFromSrc, PDBOmapStream)
+                self.parent.add_supported_stream("STREAM_OMAP_FROM_SRC", debug.DBIDbgHeader.snOmapFromSrc,
+                                                 PDBOmapStream)
             if debug.DBIDbgHeader.snFPO != -1:
                 self.parent.add_supported_stream("STREAM_FPO", debug.DBIDbgHeader.snFPO, PDBFPOStream)
-            if debug.DBIDbgHeader.snNewFPO!= -1:
+            if debug.DBIDbgHeader.snNewFPO != -1:
                 self.parent.add_supported_stream("STREAM_FPO_NEW", debug.DBIDbgHeader.snNewFPO, PDBNewFPOStream)
                 #self.parent.add_supported_stream("STREAM_FPO_STRINGS", debug.DBIDbgHeader.snNewFPO+1, PDBFPOStrings)
-            
+
             # Currently unparsed, but we know their names
             if debug.DBIDbgHeader.snXdata != -1:
                 self.parent.add_supported_stream("STREAM_XDATA", debug.DBIDbgHeader.snXdata, PDBStream)
@@ -268,44 +302,58 @@ class PDBDebugStream(ParsedPDBStream):
                 self.parent.add_supported_stream("STREAM_PDATA", debug.DBIDbgHeader.snPdata, PDBStream)
             if debug.DBIDbgHeader.snTokenRidMap != -1:
                 self.parent.add_supported_stream("STREAM_TOKEN_RID_MAP", debug.DBIDbgHeader.snTokenRidMap, PDBStream)
-            
+
 
 class PDBFPOStrings(ParsedPDBStream):
+
     def load(self):
         from pdbparse import fpo
         self.fpo_strings = fpo.FPO_STRING_DATA.parse(self.data)
+
     def get_string(self, offset):
         from construct import CString
-        return CString("x", encoding="utf8").parse(self.fpo_strings.StringData.Data[offset:])
+        return CString("x", encoding = "utf8").parse(self.fpo_strings.StringData.Data[offset:])
+
 
 class PDBFPOStream(ParsedPDBStream):
+
     def load(self):
         from pdbparse import fpo
         self.fpo = fpo.FPO_DATA_LIST.parse(self.data)
 
+
 class PDBNewFPOStream(ParsedPDBStream):
+
     def load(self):
         from pdbparse import fpo
         self.fpo = fpo.FPO_DATA_LIST_V2.parse(self.data)
+
     def load2(self):
         if self.parent:
             if not hasattr(self.parent, "STREAM_FPO_STRINGS"): return
             for f in self.fpo:
                 f.ProgramString = self.parent.STREAM_FPO_STRINGS.get_string(f.ProgramStringOffset)
 
+
 class PDBOmapStream(ParsedPDBStream):
+
     def load(self):
         from pdbparse import omap
         self.omap_data = omap.Omap(self.data)
+
     def remap(self, addr):
         return self.omap_data.remap(addr)
 
+
 class PDBSectionStream(ParsedPDBStream):
+
     def load(self):
         from pdbparse import pe
         self.sections = pe.Sections.parse(self.data)
 
+
 class PDBGlobalSymbolStream(ParsedPDBStream):
+
     def load(self):
         from pdbparse import gdata
         self.globals = gdata.parse_stream(self.stream_file)
@@ -320,6 +368,7 @@ class PDBGlobalSymbolStream(ParsedPDBStream):
                     self.vars[g.name] = g
             elif g.symtype == 2:
                 self.funcs[g.name] = g
+
 
 # Symbolic names for streams
 _stream_names7 = {
@@ -347,12 +396,14 @@ _stream_types2 = {
     PDB_STREAM_DBI: PDBDebugStream,
 }
 
+
 class PDB:
-    def __init__(self, fp, fast_load=False):
+
+    def __init__(self, fp, fast_load = False):
         self.fp = fp
         self.fast_load = fast_load
 
-    def read(self, pages, size=-1):
+    def read(self, pages, size = -1):
         """Read a portion of this PDB file, given a list of pages.
         
         Parameters :
@@ -361,14 +412,14 @@ class PDB:
         Return :
             * (bytes) the data read
         """
-        
-        assert size <= len(pages)*self.page_size
+
+        assert size <= len(pages) * self.page_size
 
         pos = self.fp.tell()
         s = b''
         for pn in pages:
-           self.fp.seek(pn*self.page_size)
-           s += self.fp.read(self.page_size)
+            self.fp.seek(pn * self.page_size)
+            s += self.fp.read(self.page_size)
         self.fp.seek(pos)
         if size == -1:
             return s
@@ -380,8 +431,8 @@ class PDB:
         self._stream_names[name] = index
 
     def _update_names(self):
-        for k,v in self._stream_names.items():
-            setattr(self,k,self.streams[v])
+        for k, v in self._stream_names.items():
+            setattr(self, k, self.streams[v])
 
     def read_root(self, rs):
         self.streams = []
@@ -392,18 +443,24 @@ class PDB:
                 pdb_cls = PDBStream
             stream_size, stream_pages = rs.streams[i]
             self.streams.append(
-                pdb_cls(self.fp, stream_pages, i, size=stream_size,
-                    page_size=self.page_size, fast_load=self.fast_load,
-                    parent=self))
+                pdb_cls(
+                    self.fp,
+                    stream_pages,
+                    i,
+                    size = stream_size,
+                    page_size = self.page_size,
+                    fast_load = self.fast_load,
+                    parent = self))
 
         # Sets up access to streams by name
         self._update_names()
-        
+
         # Second stage init. Currently only used for FPO strings
         if not self.fast_load:
             for s in self.streams:
                 if hasattr(s, 'load2'):
                     s.load2()
+
 
 class PDB7(PDB):
     """Class representing a Microsoft PDB file, version 7.
@@ -413,14 +470,14 @@ class PDB7(PDB):
 
     """
 
-    def __init__(self, fp, fast_load=False):
+    def __init__(self, fp, fast_load = False):
         PDB.__init__(self, fp, fast_load)
-        (self.signature, self.page_size, alloc_table_ptr,
-         self.num_file_pages, root_size, reserved) = unpack(_PDB7_FMT, self.fp.read(_PDB7_FMT_SIZE))
-        
+        (self.signature, self.page_size, alloc_table_ptr, self.num_file_pages, root_size,
+         reserved) = unpack(_PDB7_FMT, self.fp.read(_PDB7_FMT_SIZE))
+
         if self.signature != _PDB7_SIGNATURE:
             raise ValueError("Invalid signature for PDB version 7")
-        
+
         self._stream_map = dict(_stream_types7)
         self._stream_names = dict(_stream_names7)
 
@@ -428,54 +485,53 @@ class PDB7(PDB):
         num_root_pages = _pages(root_size, self.page_size)
 
         # How many pages are needed to store the root page list?
-        num_root_index_pages = _pages(num_root_pages*4, self.page_size)
+        num_root_index_pages = _pages(num_root_pages * 4, self.page_size)
         root_index_array_fmt = "<" + ("%dI" % num_root_index_pages)
-        root_index_pages = unpack(root_index_array_fmt,
-            self.fp.read(num_root_index_pages*4))
-        
+        root_index_pages = unpack(root_index_array_fmt, self.fp.read(num_root_index_pages * 4))
+
         # Read in the root page list
         root_page_data = b""
         for root_index in root_index_pages:
             self.fp.seek(root_index * self.page_size)
             root_page_data += self.fp.read(self.page_size)
-        
+
         # Unpack
         page_list_fmt = "<" + ("%dI" % num_root_pages)
-        root_page_list = unpack(page_list_fmt, root_page_data[:num_root_pages*4])
+        root_page_list = unpack(page_list_fmt, root_page_data[:num_root_pages * 4])
 
         #root_stream_data = self.read(root_page_list, root_size)
 
-        self.root_stream = PDB7RootStream(self.fp, root_page_list,
-            index=PDB_STREAM_ROOT, size=root_size, page_size=self.page_size)
+        self.root_stream = PDB7RootStream(
+            self.fp, root_page_list, index = PDB_STREAM_ROOT, size = root_size, page_size = self.page_size)
 
         self.read_root(self.root_stream)
 
+
 class PDB2(PDB):
-    def __init__(self, fp, fast_load=False):
+
+    def __init__(self, fp, fast_load = False):
         PDB.__init__(self, fp, fast_load)
-        (self.signature, self.page_size, start_page,
-         self.num_file_pages, root_size, reserved) = unpack(_PDB2_FMT, 
-                 self.fp.read(_PDB2_FMT_SIZE))
-        
+        (self.signature, self.page_size, start_page, self.num_file_pages, root_size,
+         reserved) = unpack(_PDB2_FMT, self.fp.read(_PDB2_FMT_SIZE))
+
         if self.signature != _PDB2_SIGNATURE:
             raise ValueError("Invalid signature for PDB version 2")
-        
+
         self._stream_map = dict(_stream_types2)
         self._stream_names = dict(_stream_names2)
 
         # Read in the root stream
         num_root_pages = _pages(root_size, self.page_size)
-        
-        page_list_fmt = "<" + ("%dH" % num_root_pages)
-        root_page_list = unpack(page_list_fmt,
-            self.fp.read(num_root_pages * 2))
 
-        self.root_stream = PDB2RootStream(self.fp, root_page_list,
-            index=PDB_STREAM_ROOT, page_size=self.page_size)
+        page_list_fmt = "<" + ("%dH" % num_root_pages)
+        root_page_list = unpack(page_list_fmt, self.fp.read(num_root_pages * 2))
+
+        self.root_stream = PDB2RootStream(self.fp, root_page_list, index = PDB_STREAM_ROOT, page_size = self.page_size)
 
         self.read_root(self.root_stream)
 
-def parse(filename, fast_load=False):
+
+def parse(filename, fast_load = False):
     "Open a PDB file and autodetect its version"
     f = open(filename, 'rb')
     sig = f.read(_PDB7_SIGNATURE_LEN)

--- a/pdbparse/__init__.py
+++ b/pdbparse/__init__.py
@@ -24,7 +24,8 @@ _PDB7_FMT_SIZE = calcsize(_PDB7_FMT)
 # "pagesize"
 def _pages(length, pagesize):
     num_pages = length // pagesize
-    if (length % pagesize): num_pages += 1
+    if (length % pagesize):
+        num_pages += 1
     return num_pages
 
 
@@ -34,8 +35,10 @@ class StreamFile:
         self.fp = fp
         self.pages = pages
         self.page_size = page_size
-        if size == -1: self.end = len(pages) * page_size
-        else: self.end = size
+        if size == -1:
+            self.end = len(pages) * page_size
+        else:
+            self.end = size
         self.pos = 0
 
     def read(self, size = -1):
@@ -60,8 +63,10 @@ class StreamFile:
         elif whence == 2:
             self.pos = self.end + offset
 
-        if self.pos < 0: self.pos = 0
-        if self.pos > self.end: self.pos = self.end
+        if self.pos < 0:
+            self.pos = 0
+        if self.pos > self.end:
+            self.pos = self.end
 
     def tell(self):
         return self.pos
@@ -109,8 +114,10 @@ class PDBStream:
         self.pages = pages
         self.index = index
         self.page_size = page_size
-        if size == -1: self.size = len(pages) * page_size
-        else: self.size = size
+        if size == -1:
+            self.size = len(pages) * page_size
+        else:
+            self.size = size
         self.stream_file = StreamFile(self.fp, pages, size = size, page_size = page_size)
 
     def reload(self):
@@ -141,8 +148,10 @@ class ParsedPDBStream(PDBStream):
                  parent = None):
         PDBStream.__init__(
             self, fp, pages, index, size = size, page_size = page_size, fast_load = fast_load, parent = parent)
-        if fast_load: return
-        else: self.load()
+        if fast_load:
+            return
+        else:
+            self.load()
 
     def load(self):
         pass
@@ -293,7 +302,7 @@ class PDBDebugStream(ParsedPDBStream):
                 self.parent.add_supported_stream("STREAM_FPO", debug.DBIDbgHeader.snFPO, PDBFPOStream)
             if debug.DBIDbgHeader.snNewFPO != -1:
                 self.parent.add_supported_stream("STREAM_FPO_NEW", debug.DBIDbgHeader.snNewFPO, PDBNewFPOStream)
-                #self.parent.add_supported_stream("STREAM_FPO_STRINGS", debug.DBIDbgHeader.snNewFPO+1, PDBFPOStrings)
+                # self.parent.add_supported_stream("STREAM_FPO_STRINGS", debug.DBIDbgHeader.snNewFPO+1, PDBFPOStrings)
 
             # Currently unparsed, but we know their names
             if debug.DBIDbgHeader.snXdata != -1:
@@ -330,7 +339,8 @@ class PDBNewFPOStream(ParsedPDBStream):
 
     def load2(self):
         if self.parent:
-            if not hasattr(self.parent, "STREAM_FPO_STRINGS"): return
+            if not hasattr(self.parent, "STREAM_FPO_STRINGS"):
+                return
             for f in self.fpo:
                 f.ProgramString = self.parent.STREAM_FPO_STRINGS.get_string(f.ProgramStringOffset)
 
@@ -360,7 +370,8 @@ class PDBGlobalSymbolStream(ParsedPDBStream):
         self.vars = {}
         self.funcs = {}
         for g in self.globals:
-            if not hasattr(g, 'symtype'): continue
+            if not hasattr(g, 'symtype'):
+                continue
             if g.symtype == 0:
                 if g.name.startswith("_"):
                     self.vars[g.name[1:]] = g
@@ -392,7 +403,7 @@ _stream_types7 = {
 
 _stream_types2 = {
     PDB_STREAM_TPI: PDBTypeStream,
-    #PDB_STREAM_PDB: PDBInfoStream,
+    # PDB_STREAM_PDB: PDBInfoStream,
     PDB_STREAM_DBI: PDBDebugStream,
 }
 
@@ -499,7 +510,7 @@ class PDB7(PDB):
         page_list_fmt = "<" + ("%dI" % num_root_pages)
         root_page_list = unpack(page_list_fmt, root_page_data[:num_root_pages * 4])
 
-        #root_stream_data = self.read(root_page_list, root_size)
+        # root_stream_data = self.read(root_page_list, root_size)
 
         self.root_stream = PDB7RootStream(
             self.fp, root_page_list, index = PDB_STREAM_ROOT, size = root_size, page_size = self.page_size)

--- a/pdbparse/__init__.py
+++ b/pdbparse/__init__.py
@@ -328,7 +328,7 @@ class PDBFPOStream(ParsedPDBStream):
 
     def load(self):
         from pdbparse import fpo
-        self.fpo = fpo.FPO_DATA_LIST.parse(self.data)
+        self.fpo = fpo.parse_FPO_DATA_LIST(self.data)
 
 
 class PDBNewFPOStream(ParsedPDBStream):

--- a/pdbparse/dbgold.py
+++ b/pdbparse/dbgold.py
@@ -1,29 +1,27 @@
 #!/usr/bin/env python
 
 from construct import *
-from pdbparse.pe import IMAGE_SECTION_HEADER
-from pdbparse.fpo import FPO_DATA
+
 from pdbparse.info import GUID
+from pdbparse.pe import IMAGE_SECTION_HEADER
 
-CV_RSDS_HEADER = Struct(
-    "CV_RSDS",
-    Const(Bytes("Signature", 4), b"RSDS"),
-    GUID("GUID"),
-    ULInt32("Age"),
-    CString("Filename", encoding = "utf8"),
+CV_RSDS_HEADER = "CV_RSDS" / Struct(
+    "Signature" / Const(b"RSDS", Bytes(4)),
+    "GUID" / GUID,
+    "Age" / Int32ul,
+    "Filename" / CString(encoding = "utf8"),
 )
 
-CV_NB10_HEADER = Struct(
-    "CV_NB10",
-    Const(Bytes("Signature", 4), b"NB10"),
-    ULInt32("Offset"),
-    ULInt32("Timestamp"),
-    ULInt32("Age"),
-    CString("Filename", encoding = "utf8"),
+CV_NB10_HEADER = "CV_NB10" / Struct(
+    "Signature" / Const(b"NB10", Bytes(4)),
+    "Offset" / Int32ul,
+    "Timestamp" / Int32ul,
+    "Age" / Int32ul,
+    "Filename" / CString(encoding = "utf8"),
 )
 
-DebugDirectoryType = Enum(
-    ULInt32("Type"),
+DebugDirectoryType = "Type" / Enum(
+    Int32ul,
     IMAGE_DEBUG_TYPE_UNKNOWN = 0,
     IMAGE_DEBUG_TYPE_COFF = 1,
     IMAGE_DEBUG_TYPE_CODEVIEW = 2,
@@ -38,67 +36,63 @@ DebugDirectoryType = Enum(
     _default_ = "IMAGE_DEBUG_TYPE_UNKNOWN",
 )
 
-DebugMiscType = Enum(
-    ULInt32("Type"),
+DebugMiscType = "Type" / Enum(
+    Int32ul,
     IMAGE_DEBUG_MISC_EXENAME = 1,
     _default_ = Pass,
 )
 
-IMAGE_SEPARATE_DEBUG_HEADER = Struct(
-    "IMAGE_SEPARATE_DEBUG_HEADER",
-    Const(Bytes("Signature", 2), b"DI"),
-    ULInt16("Flags"),
-    ULInt16("Machine"),
-    ULInt16("Characteristics"),
-    ULInt32("TimeDateStamp"),
-    ULInt32("CheckSum"),
-    ULInt32("ImageBase"),
-    ULInt32("SizeOfImage"),
-    ULInt32("NumberOfSections"),
-    ULInt32("ExportedNamesSize"),
-    ULInt32("DebugDirectorySize"),
-    ULInt32("SectionAlignment"),
-    Array(2, ULInt32("Reserved")),
+IMAGE_SEPARATE_DEBUG_HEADER = "IMAGE_SEPARATE_DEBUG_HEADER" / Struct(
+    "Signature" / Const(b"DI", Bytes(2)),
+    "Flags" / Int16ul,
+    "Machine" / Int16ul,
+    "Characteristics" / Int16ul,
+    "TimeDateStamp" / Int16ul,
+    "CheckSum" / Int16ul,
+    "ImageBase" / Int16ul,
+    "SizeOfImage" / Int16ul,
+    "NumberOfSections" / Int16ul,
+    "ExportedNamesSize" / Int16ul,
+    "DebugDirectorySize" / Int16ul,
+    "SectionAlignment" / Int16ul,
+    Array(2, "Reserved" / Int32ul),
 )
 
-IMAGE_DEBUG_DIRECTORY = Struct(
-    "IMAGE_DEBUG_DIRECTORY",
-    ULInt32("Characteristics"),
-    ULInt32("TimeDateStamp"),
-    ULInt16("MajorVersion"),
-    ULInt16("MinorVersion"),
+IMAGE_DEBUG_DIRECTORY = "IMAGE_DEBUG_DIRECTORY" / Struct(
+    "Characteristics" / Int32ul,
+    "TimeDateStamp" / Int32ul,
+    "MajorVersion" / Int16ul,
+    "MinorVersion" / Int16ul,
     DebugDirectoryType,
-    ULInt32("SizeOfData"),
-    ULInt32("AddressOfRawData"),
-    ULInt32("PointerToRawData"),
-    Pointer(lambda ctx: ctx.PointerToRawData, String("Data", lambda ctx: ctx.SizeOfData)),
+    "SizeOfData" / Int32ul,
+    "AddressOfRawData" / Int32ul,
+    "PointerToRawData" / Int32ul,
+    "Data" / Pointer(lambda ctx: ctx.PointerToRawData, Bytes(lambda ctx: ctx.SizeOfData)),
 )
 
-IMAGE_DEBUG_MISC = Struct(
-    "IMAGE_DEBUG_MISC",
+IMAGE_DEBUG_MISC = "IMAGE_DEBUG_MISC" / Struct(
     DebugMiscType,
-    ULInt32("Length"),
-    Byte("Unicode"),
-    Array(3, Byte("Reserved")),
-    Tunnel(
-        String("Strings", lambda ctx: ctx.Length - 12),
-        GreedyRange(CString("Strings", encoding = "utf8")),
+    "Length" / Int32ul,
+    "Unicode" / Byte,
+    Array(3, "Reserved" / Byte),
+    "Strings" / RestreamData(
+        Bytes(lambda ctx: ctx.Length - 12),
+        GreedyRange(CString(encoding = "utf8")),
     ),
 )
 
-IMAGE_FUNCTION_ENTRY = Struct(
-    "IMAGE_FUNCTION_ENTRY",
-    ULInt32("StartingAddress"),
-    ULInt32("EndingAddress"),
-    ULInt32("EndOfPrologue"),
+IMAGE_FUNCTION_ENTRY = "IMAGE_FUNCTION_ENTRY" / Struct(
+    "StartingAddress" / Int32ul,
+    "EndingAddress" / Int32ul,
+    "EndOfPrologue" / Int32ul,
 )
 
-DbgFile = Struct(
-    "DbgFile", IMAGE_SEPARATE_DEBUG_HEADER,
+DbgFile = "DbgFile" / Struct(
+    IMAGE_SEPARATE_DEBUG_HEADER,
     Array(lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.NumberOfSections, IMAGE_SECTION_HEADER),
-    Tunnel(
-        String("data", lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.ExportedNamesSize),
-        GreedyRange(CString("ExportedNames", encoding = "utf8")),
+    "ExportedNames" / RestreamData(
+        PaddedString(lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.ExportedNamesSize),
+        GreedyRange(CString(encoding = "utf8")),
     ),
     Array(lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.DebugDirectorySize / IMAGE_DEBUG_DIRECTORY.sizeof(),
           IMAGE_DEBUG_DIRECTORY))

--- a/pdbparse/dbgold.py
+++ b/pdbparse/dbgold.py
@@ -5,42 +5,47 @@ from pdbparse.pe import IMAGE_SECTION_HEADER
 from pdbparse.fpo import FPO_DATA
 from pdbparse.info import GUID
 
-CV_RSDS_HEADER = Struct("CV_RSDS",
+CV_RSDS_HEADER = Struct(
+    "CV_RSDS",
     Const(Bytes("Signature", 4), b"RSDS"),
     GUID("GUID"),
     ULInt32("Age"),
-    CString("Filename", encoding="utf8"),
+    CString("Filename", encoding = "utf8"),
 )
 
-CV_NB10_HEADER = Struct("CV_NB10",
+CV_NB10_HEADER = Struct(
+    "CV_NB10",
     Const(Bytes("Signature", 4), b"NB10"),
     ULInt32("Offset"),
     ULInt32("Timestamp"),
     ULInt32("Age"),
-    CString("Filename", encoding="utf8"),
+    CString("Filename", encoding = "utf8"),
 )
 
-DebugDirectoryType = Enum(ULInt32("Type"),
-    IMAGE_DEBUG_TYPE_UNKNOWN        = 0,
-    IMAGE_DEBUG_TYPE_COFF           = 1,
-    IMAGE_DEBUG_TYPE_CODEVIEW       = 2,
-    IMAGE_DEBUG_TYPE_FPO            = 3,
-    IMAGE_DEBUG_TYPE_MISC           = 4,
-    IMAGE_DEBUG_TYPE_EXCEPTION      = 5,
-    IMAGE_DEBUG_TYPE_FIXUP          = 6,
-    IMAGE_DEBUG_TYPE_OMAP_TO_SRC    = 7,
-    IMAGE_DEBUG_TYPE_OMAP_FROM_SRC  = 8,
-    IMAGE_DEBUG_TYPE_BORLAND        = 9,
-    IMAGE_DEBUG_TYPE_RESERVED       = 10,
+DebugDirectoryType = Enum(
+    ULInt32("Type"),
+    IMAGE_DEBUG_TYPE_UNKNOWN = 0,
+    IMAGE_DEBUG_TYPE_COFF = 1,
+    IMAGE_DEBUG_TYPE_CODEVIEW = 2,
+    IMAGE_DEBUG_TYPE_FPO = 3,
+    IMAGE_DEBUG_TYPE_MISC = 4,
+    IMAGE_DEBUG_TYPE_EXCEPTION = 5,
+    IMAGE_DEBUG_TYPE_FIXUP = 6,
+    IMAGE_DEBUG_TYPE_OMAP_TO_SRC = 7,
+    IMAGE_DEBUG_TYPE_OMAP_FROM_SRC = 8,
+    IMAGE_DEBUG_TYPE_BORLAND = 9,
+    IMAGE_DEBUG_TYPE_RESERVED = 10,
     _default_ = "IMAGE_DEBUG_TYPE_UNKNOWN",
 )
 
-DebugMiscType = Enum(ULInt32("Type"),
-    IMAGE_DEBUG_MISC_EXENAME        = 1,
+DebugMiscType = Enum(
+    ULInt32("Type"),
+    IMAGE_DEBUG_MISC_EXENAME = 1,
     _default_ = Pass,
 )
 
-IMAGE_SEPARATE_DEBUG_HEADER = Struct("IMAGE_SEPARATE_DEBUG_HEADER",
+IMAGE_SEPARATE_DEBUG_HEADER = Struct(
+    "IMAGE_SEPARATE_DEBUG_HEADER",
     Const(Bytes("Signature", 2), b"DI"),
     ULInt16("Flags"),
     ULInt16("Machine"),
@@ -53,10 +58,11 @@ IMAGE_SEPARATE_DEBUG_HEADER = Struct("IMAGE_SEPARATE_DEBUG_HEADER",
     ULInt32("ExportedNamesSize"),
     ULInt32("DebugDirectorySize"),
     ULInt32("SectionAlignment"),
-    Array(2,ULInt32("Reserved")),
+    Array(2, ULInt32("Reserved")),
 )
 
-IMAGE_DEBUG_DIRECTORY = Struct("IMAGE_DEBUG_DIRECTORY",
+IMAGE_DEBUG_DIRECTORY = Struct(
+    "IMAGE_DEBUG_DIRECTORY",
     ULInt32("Characteristics"),
     ULInt32("TimeDateStamp"),
     ULInt16("MajorVersion"),
@@ -65,37 +71,34 @@ IMAGE_DEBUG_DIRECTORY = Struct("IMAGE_DEBUG_DIRECTORY",
     ULInt32("SizeOfData"),
     ULInt32("AddressOfRawData"),
     ULInt32("PointerToRawData"),
-    Pointer(lambda ctx: ctx.PointerToRawData,
-        String("Data", lambda ctx: ctx.SizeOfData)
-    ),
+    Pointer(lambda ctx: ctx.PointerToRawData, String("Data", lambda ctx: ctx.SizeOfData)),
 )
 
-IMAGE_DEBUG_MISC = Struct("IMAGE_DEBUG_MISC",
+IMAGE_DEBUG_MISC = Struct(
+    "IMAGE_DEBUG_MISC",
     DebugMiscType,
     ULInt32("Length"),
     Byte("Unicode"),
     Array(3, Byte("Reserved")),
     Tunnel(
         String("Strings", lambda ctx: ctx.Length - 12),
-        GreedyRange(CString("Strings", encoding="utf8")),
+        GreedyRange(CString("Strings", encoding = "utf8")),
     ),
 )
 
-IMAGE_FUNCTION_ENTRY = Struct("IMAGE_FUNCTION_ENTRY",
+IMAGE_FUNCTION_ENTRY = Struct(
+    "IMAGE_FUNCTION_ENTRY",
     ULInt32("StartingAddress"),
     ULInt32("EndingAddress"),
     ULInt32("EndOfPrologue"),
 )
 
-DbgFile = Struct("DbgFile",
-    IMAGE_SEPARATE_DEBUG_HEADER,
-    Array(lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.NumberOfSections,
-        IMAGE_SECTION_HEADER),
+DbgFile = Struct(
+    "DbgFile", IMAGE_SEPARATE_DEBUG_HEADER,
+    Array(lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.NumberOfSections, IMAGE_SECTION_HEADER),
     Tunnel(
-        String("data",
-            lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.ExportedNamesSize),
-        GreedyRange(CString("ExportedNames", encoding="utf8")),
+        String("data", lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.ExportedNamesSize),
+        GreedyRange(CString("ExportedNames", encoding = "utf8")),
     ),
-    Array(lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.DebugDirectorySize 
-                  / IMAGE_DEBUG_DIRECTORY.sizeof(), IMAGE_DEBUG_DIRECTORY)
-)
+    Array(lambda ctx: ctx.IMAGE_SEPARATE_DEBUG_HEADER.DebugDirectorySize / IMAGE_DEBUG_DIRECTORY.sizeof(),
+          IMAGE_DEBUG_DIRECTORY))

--- a/pdbparse/dbi.py
+++ b/pdbparse/dbi.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-# Python 2 and 3
-from io import BytesIO
-
 # Python 2 and 3: forward-compatible
 from builtins import range
+# Python 2 and 3
+from io import BytesIO
 
 from construct import *
 
@@ -16,42 +15,40 @@ def get_parsed_size(tp, con):
 
 
 def SymbolRange(name):
-    return Struct(
-        name,
-        SLInt16("section"),
+    return name / Struct(
+        "section" / Int16sl,
         Padding(2),
-        SLInt32("offset"),
-        SLInt32("size"),
-        ULInt32("flags"),
-        SLInt16("module"),
+        "offset" / Int32sl,
+        "size" / Int32sl,
+        "flags" / Int32ul,
+        "module" / Int16sl,
         Padding(2),
-        ULInt32("dataCRC"),
-        ULInt32("relocCRC"),
+        "dataCRC" / Int32ul,
+        "relocCRC" / Int32ul,
     )
 
 
-DBIHeader = Struct(
-    "DBIHeader",
-    Const(Bytes("magic", 4), b"\xFF\xFF\xFF\xFF"),  # 0
-    ULInt32("version"),  # 4
-    ULInt32("age"),  # 8
-    SLInt16("gssymStream"),  # 12
-    ULInt16("vers"),  # 14
-    SLInt16("pssymStream"),  # 16
-    ULInt16("pdbver"),  # 18
-    SLInt16("symrecStream"),  # stream containing global symbols   # 20
-    ULInt16("pdbver2"),  # 22
-    ULInt32("module_size"),  # total size of DBIExHeaders            # 24
-    ULInt32("secconSize"),  # 28
-    ULInt32("secmapSize"),  # 32
-    ULInt32("filinfSize"),  # 36
-    ULInt32("tsmapSize"),  # 40
-    ULInt32("mfcIndex"),  # 44
-    ULInt32("dbghdrSize"),  # 48
-    ULInt32("ecinfoSize"),  # 52
-    ULInt16("flags"),  # 56
-    Enum(
-        ULInt16("Machine"),  # 58
+DBIHeader = "DBIHeader" / Struct(
+    "magic" / Const(b"\xFF\xFF\xFF\xFF", Bytes(4)),  # 0
+    "version" / Int32ul,  # 4
+    "age" / Int32ul,  # 8
+    "gssymStream" / Int16sl,  # 12
+    "vers" / Int16ul,  # 14
+    "pssymStream" / Int16sl,  # 16
+    "pdbver" / Int16ul,  # 18
+    "symrecStream" / Int16sl,  # stream containing global symbols   # 20
+    "pdbver2" / Int16ul,  # 22
+    "module_size" / Int32ul,  # total size of DBIExHeaders            # 24
+    "secconSize" / Int32ul,  # 28
+    "secmapSize" / Int32ul,  # 32
+    "filinfSize" / Int32ul,  # 36
+    "tsmapSize" / Int32ul,  # 40
+    "mfcIndex" / Int32ul,  # 44
+    "dbghdrSize" / Int32ul,  # 48
+    "ecinfoSize" / Int32ul,  # 52
+    "flags" / Int16ul,  # 56
+    "Machine" / Enum(
+        Int16ul,  # 58
         IMAGE_FILE_MACHINE_UNKNOWN = 0x0000,
         IMAGE_FILE_MACHINE_I386 = 0x014c,
         IMAGE_FILE_MACHINE_R3000 = 0x0162,
@@ -83,46 +80,43 @@ DBIHeader = Struct(
         IMAGE_FILE_MACHINE_M32R = 0x9041,
         IMAGE_FILE_MACHINE_CEE = 0xc0ee,
     ),
-    ULInt32("resvd"),  # 60
+    "resvd" / Int32ul,  # 60
 )
 
-DBIExHeader = Struct(
-    "DBIExHeader",
-    ULInt32("opened"),
+DBIExHeader = "DBIExHeader" / Struct(
+    "opened" / Int32ul,
     SymbolRange("range"),
-    ULInt16("flags"),
-    SLInt16("stream"),
-    ULInt32("symSize"),
-    ULInt32("oldLineSize"),
-    ULInt32("lineSize"),
-    SLInt16("nSrcFiles"),
+    "flags" / Int16ul,
+    "stream" / Int16sl,
+    "symSize" / Int32ul,
+    "oldLineSize" / Int32ul,
+    "lineSize" / Int32ul,
+    "nSrcFiles" / Int16sl,
     Padding(2),
-    ULInt32("offsets"),
-    ULInt32("niSource"),
-    ULInt32("niCompiler"),
-    CString("modName", encoding = "utf8"),
-    CString("objName", encoding = "utf8"),
+    "offsets" / Int32ul,
+    "niSource" / Int32ul,
+    "niCompiler" / Int32ul,
+    "modName" / CString(encoding = "utf8"),
+    "objName" / CString(encoding = "utf8"),
 )
 
-DbiDbgHeader = Struct(
-    "DbiDbgHeader",
-    SLInt16("snFPO"),
-    SLInt16("snException"),
-    SLInt16("snFixup"),
-    SLInt16("snOmapToSrc"),
-    SLInt16("snOmapFromSrc"),
-    SLInt16("snSectionHdr"),
-    SLInt16("snTokenRidMap"),
-    SLInt16("snXdata"),
-    SLInt16("snPdata"),
-    SLInt16("snNewFPO"),
-    SLInt16("snSectionHdrOrig"),
+DbiDbgHeader = "DbiDbgHeader" / Struct(
+    "snFPO" / Int16sl,
+    "snException" / Int16sl,
+    "snFixup" / Int16sl,
+    "snOmapToSrc" / Int16sl,
+    "snOmapFromSrc" / Int16sl,
+    "snSectionHdr" / Int16sl,
+    "snTokenRidMap" / Int16sl,
+    "snXdata" / Int16sl,
+    "snPdata" / Int16sl,
+    "snNewFPO" / Int16sl,
+    "snSectionHdrOrig" / Int16sl,
 )
 
-sstFileIndex = Struct(
-    "sstFileIndex",
-    ULInt16("cMod"),
-    ULInt16("cRef"),
+sstFileIndex = "sstFileIndex" / Struct(
+    "cMod" / Int16ul,
+    "cRef" / Int16ul,
 )
 
 
@@ -139,7 +133,8 @@ def parse_stream(stream):
     while dbiexhdr_data:
         dbiexhdrs.append(DBIExHeader.parse(dbiexhdr_data))
         sz = get_parsed_size(DBIExHeader, dbiexhdrs[-1])
-        if sz % _ALIGN != 0: sz = sz + (_ALIGN - (sz % _ALIGN))
+        if sz % _ALIGN != 0:
+            sz = sz + (_ALIGN - (sz % _ALIGN))
         dbiexhdr_data = dbiexhdr_data[sz:]
 
     # "Section Contribution"
@@ -153,21 +148,21 @@ def parse_stream(stream):
     # "File Info"
     end = stream.tell() + dbihdr.filinfSize
     fileIndex = sstFileIndex.parse_stream(stream)
-    modStart = Array(fileIndex.cMod, ULInt16("modStart")).parse_stream(stream)
-    cRefCnt = Array(fileIndex.cMod, ULInt16("cRefCnt")).parse_stream(stream)
-    NameRef = Array(fileIndex.cRef, ULInt32("NameRef")).parse_stream(stream)
+    modStart = Array(fileIndex.cMod, Int16ul).parse_stream(stream)
+    cRefCnt = Array(fileIndex.cMod, Int16ul).parse_stream(stream)
+    NameRef = Array(fileIndex.cRef, Int32ul).parse_stream(stream)
     modules = []  # array of arrays of files
     files = []  # array of files (non unique)
     Names = stream.read(end - stream.tell())
     for i in range(0, fileIndex.cMod):
         these = []
         for j in range(modStart[i], modStart[i] + cRefCnt[i]):
-            Name = CString("Name", encoding = "utf8").parse(Names[NameRef[j]:])
+            Name = "Name" / CString(encoding = "utf8").parse(Names[NameRef[j]:])
             files.append(Name)
             these.append(Name)
         modules.append(these)
 
-    #stream.seek(dbihdr.filinfSize, 1)
+    # stream.seek(dbihdr.filinfSize, 1)
     # "TSM"
     stream.seek(dbihdr.tsmapSize, 1)
     # "EC"

--- a/pdbparse/dbi.py
+++ b/pdbparse/dbi.py
@@ -4,17 +4,20 @@
 from io import BytesIO
 
 # Python 2 and 3: forward-compatible
-from builtins import range 
+from builtins import range
 
 from construct import *
 
 _ALIGN = 4
 
-def get_parsed_size(tp,con):
+
+def get_parsed_size(tp, con):
     return len(tp.build(con))
 
-def SymbolRange(name): 
-    return Struct(name,
+
+def SymbolRange(name):
+    return Struct(
+        name,
         SLInt16("section"),
         Padding(2),
         SLInt32("offset"),
@@ -26,61 +29,65 @@ def SymbolRange(name):
         ULInt32("relocCRC"),
     )
 
-DBIHeader = Struct("DBIHeader",
-    Const(Bytes("magic", 4), b"\xFF\xFF\xFF\xFF"),                          # 0
-    ULInt32("version"),                                                     # 4
-    ULInt32("age"),                                                         # 8
-    SLInt16("gssymStream"),                                                 # 12
-    ULInt16("vers"),                                                        # 14
-    SLInt16("pssymStream"),                                                 # 16
-    ULInt16("pdbver"),                                                      # 18
-    SLInt16("symrecStream"),           # stream containing global symbols   # 20
-    ULInt16("pdbver2"),                                                     # 22
-    ULInt32("module_size"),         # total size of DBIExHeaders            # 24
-    ULInt32("secconSize"),                                                  # 28
-    ULInt32("secmapSize"),                                                  # 32
-    ULInt32("filinfSize"),                                                  # 36
-    ULInt32("tsmapSize"),                                                   # 40
-    ULInt32("mfcIndex"),                                                    # 44
-    ULInt32("dbghdrSize"),                                                  # 48
-    ULInt32("ecinfoSize"),                                                  # 52
-    ULInt16("flags"),                                                       # 56
-    Enum(ULInt16("Machine"),                                                # 58
-        IMAGE_FILE_MACHINE_UNKNOWN   = 0x0000,
-        IMAGE_FILE_MACHINE_I386      = 0x014c,
-        IMAGE_FILE_MACHINE_R3000     = 0x0162,
-        IMAGE_FILE_MACHINE_R4000     = 0x0166,
-        IMAGE_FILE_MACHINE_R10000    = 0x0168,
+
+DBIHeader = Struct(
+    "DBIHeader",
+    Const(Bytes("magic", 4), b"\xFF\xFF\xFF\xFF"),  # 0
+    ULInt32("version"),  # 4
+    ULInt32("age"),  # 8
+    SLInt16("gssymStream"),  # 12
+    ULInt16("vers"),  # 14
+    SLInt16("pssymStream"),  # 16
+    ULInt16("pdbver"),  # 18
+    SLInt16("symrecStream"),  # stream containing global symbols   # 20
+    ULInt16("pdbver2"),  # 22
+    ULInt32("module_size"),  # total size of DBIExHeaders            # 24
+    ULInt32("secconSize"),  # 28
+    ULInt32("secmapSize"),  # 32
+    ULInt32("filinfSize"),  # 36
+    ULInt32("tsmapSize"),  # 40
+    ULInt32("mfcIndex"),  # 44
+    ULInt32("dbghdrSize"),  # 48
+    ULInt32("ecinfoSize"),  # 52
+    ULInt16("flags"),  # 56
+    Enum(
+        ULInt16("Machine"),  # 58
+        IMAGE_FILE_MACHINE_UNKNOWN = 0x0000,
+        IMAGE_FILE_MACHINE_I386 = 0x014c,
+        IMAGE_FILE_MACHINE_R3000 = 0x0162,
+        IMAGE_FILE_MACHINE_R4000 = 0x0166,
+        IMAGE_FILE_MACHINE_R10000 = 0x0168,
         IMAGE_FILE_MACHINE_WCEMIPSV2 = 0x0169,
-        IMAGE_FILE_MACHINE_ALPHA     = 0x0184,
-        IMAGE_FILE_MACHINE_SH3       = 0x01a2,
-        IMAGE_FILE_MACHINE_SH3DSP    = 0x01a3,
-        IMAGE_FILE_MACHINE_SH3E      = 0x01a4,
-        IMAGE_FILE_MACHINE_SH4       = 0x01a6,
-        IMAGE_FILE_MACHINE_SH5       = 0x01a8,
-        IMAGE_FILE_MACHINE_ARM       = 0x01c0,
-        IMAGE_FILE_MACHINE_THUMB     = 0x01c2,
-        IMAGE_FILE_MACHINE_ARMNT     = 0x01c4,
-        IMAGE_FILE_MACHINE_AM33      = 0x01d3,
-        IMAGE_FILE_MACHINE_POWERPC   = 0x01f0,
+        IMAGE_FILE_MACHINE_ALPHA = 0x0184,
+        IMAGE_FILE_MACHINE_SH3 = 0x01a2,
+        IMAGE_FILE_MACHINE_SH3DSP = 0x01a3,
+        IMAGE_FILE_MACHINE_SH3E = 0x01a4,
+        IMAGE_FILE_MACHINE_SH4 = 0x01a6,
+        IMAGE_FILE_MACHINE_SH5 = 0x01a8,
+        IMAGE_FILE_MACHINE_ARM = 0x01c0,
+        IMAGE_FILE_MACHINE_THUMB = 0x01c2,
+        IMAGE_FILE_MACHINE_ARMNT = 0x01c4,
+        IMAGE_FILE_MACHINE_AM33 = 0x01d3,
+        IMAGE_FILE_MACHINE_POWERPC = 0x01f0,
         IMAGE_FILE_MACHINE_POWERPCFP = 0x01f1,
-        IMAGE_FILE_MACHINE_IA64      = 0x0200,
-        IMAGE_FILE_MACHINE_MIPS16    = 0x0266,
-        IMAGE_FILE_MACHINE_ALPHA64   = 0x0284,
-        IMAGE_FILE_MACHINE_AXP64     = 0x0284,
-        IMAGE_FILE_MACHINE_MIPSFPU   = 0x0366,
+        IMAGE_FILE_MACHINE_IA64 = 0x0200,
+        IMAGE_FILE_MACHINE_MIPS16 = 0x0266,
+        IMAGE_FILE_MACHINE_ALPHA64 = 0x0284,
+        IMAGE_FILE_MACHINE_AXP64 = 0x0284,
+        IMAGE_FILE_MACHINE_MIPSFPU = 0x0366,
         IMAGE_FILE_MACHINE_MIPSFPU16 = 0x0466,
-        IMAGE_FILE_MACHINE_TRICORE   = 0x0520,
-        IMAGE_FILE_MACHINE_CEF       = 0x0cef,
-        IMAGE_FILE_MACHINE_EBC       = 0x0ebc,
-        IMAGE_FILE_MACHINE_AMD64     = 0x8664,
-        IMAGE_FILE_MACHINE_M32R      = 0x9041,
-        IMAGE_FILE_MACHINE_CEE       = 0xc0ee,
+        IMAGE_FILE_MACHINE_TRICORE = 0x0520,
+        IMAGE_FILE_MACHINE_CEF = 0x0cef,
+        IMAGE_FILE_MACHINE_EBC = 0x0ebc,
+        IMAGE_FILE_MACHINE_AMD64 = 0x8664,
+        IMAGE_FILE_MACHINE_M32R = 0x9041,
+        IMAGE_FILE_MACHINE_CEE = 0xc0ee,
     ),
-    ULInt32("resvd"),                                                       # 60
+    ULInt32("resvd"),  # 60
 )
 
-DBIExHeader = Struct("DBIExHeader",
+DBIExHeader = Struct(
+    "DBIExHeader",
     ULInt32("opened"),
     SymbolRange("range"),
     ULInt16("flags"),
@@ -93,11 +100,12 @@ DBIExHeader = Struct("DBIExHeader",
     ULInt32("offsets"),
     ULInt32("niSource"),
     ULInt32("niCompiler"),
-    CString("modName", encoding="utf8"),
-    CString("objName", encoding="utf8"),
+    CString("modName", encoding = "utf8"),
+    CString("objName", encoding = "utf8"),
 )
 
-DbiDbgHeader = Struct("DbiDbgHeader",
+DbiDbgHeader = Struct(
+    "DbiDbgHeader",
     SLInt16("snFPO"),
     SLInt16("snException"),
     SLInt16("snFixup"),
@@ -111,10 +119,12 @@ DbiDbgHeader = Struct("DbiDbgHeader",
     SLInt16("snSectionHdrOrig"),
 )
 
-sstFileIndex = Struct("sstFileIndex",
+sstFileIndex = Struct(
+    "sstFileIndex",
     ULInt16("cMod"),
     ULInt16("cRef"),
 )
+
 
 def parse_stream(stream):
     pos = 0
@@ -128,10 +138,10 @@ def parse_stream(stream):
     dbiexhdrs = []
     while dbiexhdr_data:
         dbiexhdrs.append(DBIExHeader.parse(dbiexhdr_data))
-        sz = get_parsed_size(DBIExHeader,dbiexhdrs[-1])
+        sz = get_parsed_size(DBIExHeader, dbiexhdrs[-1])
         if sz % _ALIGN != 0: sz = sz + (_ALIGN - (sz % _ALIGN))
         dbiexhdr_data = dbiexhdr_data[sz:]
-    
+
     # "Section Contribution"
     stream.seek(dbihdr.secconSize, 1)
     # "Section Map"
@@ -146,13 +156,13 @@ def parse_stream(stream):
     modStart = Array(fileIndex.cMod, ULInt16("modStart")).parse_stream(stream)
     cRefCnt = Array(fileIndex.cMod, ULInt16("cRefCnt")).parse_stream(stream)
     NameRef = Array(fileIndex.cRef, ULInt32("NameRef")).parse_stream(stream)
-    modules = [] # array of arrays of files
-    files = [] # array of files (non unique)
+    modules = []  # array of arrays of files
+    files = []  # array of files (non unique)
     Names = stream.read(end - stream.tell())
     for i in range(0, fileIndex.cMod):
         these = []
-        for j in range(modStart[i], modStart[i]+cRefCnt[i]):
-            Name = CString("Name", encoding="utf8").parse(Names[NameRef[j]:])
+        for j in range(modStart[i], modStart[i] + cRefCnt[i]):
+            Name = CString("Name", encoding = "utf8").parse(Names[NameRef[j]:])
             files.append(Name)
             these.append(Name)
         modules.append(these)
@@ -164,12 +174,14 @@ def parse_stream(stream):
     stream.seek(dbihdr.ecinfoSize, 1)
     # The data we really want
     dbghdr = DbiDbgHeader.parse_stream(stream)
-    
-    return Container(DBIHeader=dbihdr,
-                     DBIExHeaders=ListContainer(dbiexhdrs),
-                     DBIDbgHeader=dbghdr,
-                     modules=modules,
-                     files=files)
+
+    return Container(
+        DBIHeader = dbihdr,
+        DBIExHeaders = ListContainer(dbiexhdrs),
+        DBIDbgHeader = dbghdr,
+        modules = modules,
+        files = files)
+
 
 def parse(data):
     return parse_stream(BytesIO(data))

--- a/pdbparse/fpo.py
+++ b/pdbparse/fpo.py
@@ -1,34 +1,39 @@
 from construct import *
 
 # FPO DATA
-FPO_DATA = Struct("FPO_DATA",
-    ULInt32("ulOffStart"),          # offset 1st byte of function code
-    ULInt32("cbProcSize"),          # number of bytes in function
-    ULInt32("cdwLocals"),           # number of bytes in locals/4
-    ULInt16("cdwParams"),           # number of bytes in params/4
-    Embed(BitStruct("BitValues",
-        Octet("cbProlog"),          # number of bytes in prolog
-        BitField("cbFrame",2),      # frame type
-        Bit("reserved"),            # reserved for future use
-        Flag("fUseBP"),             # TRUE if EBP has been allocated
-        Flag("fHasSEH"),            # TRUE if SEH in func
-        BitField("cbRegs",3),       # number of regs saved
-    )),
+FPO_DATA = Struct(
+    "FPO_DATA",
+    ULInt32("ulOffStart"),  # offset 1st byte of function code
+    ULInt32("cbProcSize"),  # number of bytes in function
+    ULInt32("cdwLocals"),  # number of bytes in locals/4
+    ULInt16("cdwParams"),  # number of bytes in params/4
+    Embed(
+        BitStruct(
+            "BitValues",
+            Octet("cbProlog"),  # number of bytes in prolog
+            BitField("cbFrame", 2),  # frame type
+            Bit("reserved"),  # reserved for future use
+            Flag("fUseBP"),  # TRUE if EBP has been allocated
+            Flag("fHasSEH"),  # TRUE if SEH in func
+            BitField("cbRegs", 3),  # number of regs saved
+        )),
 )
 
 # New style FPO records with program strings
-FPO_DATA_V2 = Struct("FPO_DATA_V2",
+FPO_DATA_V2 = Struct(
+    "FPO_DATA_V2",
     ULInt32("ulOffStart"),
     ULInt32("cbProcSize"),
     ULInt32("cbLocals"),
     ULInt32("cbParams"),
-    ULInt32("maxStack"),        # so far only observed to be 0
+    ULInt32("maxStack"),  # so far only observed to be 0
     ULInt32("ProgramStringOffset"),
     ULInt16("cbProlog"),
     ULInt16("cbSavedRegs"),
-    FlagsEnum(ULInt32("flags"),
+    FlagsEnum(
+        ULInt32("flags"),
         SEH = 1,
-        CPPEH = 2,              # conjectured
+        CPPEH = 2,  # conjectured
         fnStart = 4,
     ),
 )
@@ -40,18 +45,20 @@ FPO_DATA_LIST_V2 = GreedyRange(FPO_DATA_V2)
 # Program string storage
 # May move this to a new file; in private symbols the values
 # include things that are not just FPO related.
-FPO_STRING_DATA = Struct("FPO_STRING_DATA",
-    Const(Bytes("Signature",4), b"\xFE\xEF\xFE\xEF"),
+FPO_STRING_DATA = Struct(
+    "FPO_STRING_DATA",
+    Const(Bytes("Signature", 4), b"\xFE\xEF\xFE\xEF"),
     ULInt32("Unk1"),
     ULInt32("szDataLen"),
-    Union("StringData",
-        String("Data",lambda ctx: ctx._.szDataLen),
+    Union(
+        "StringData",
+        String("Data", lambda ctx: ctx._.szDataLen),
         Tunnel(
-            String("Strings",lambda ctx: ctx._.szDataLen),
-            GreedyRange(CString("Strings", encoding="utf8")),
+            String("Strings", lambda ctx: ctx._.szDataLen),
+            GreedyRange(CString("Strings", encoding = "utf8")),
         ),
     ),
-    ULInt32("lastDwIndex"), # data remaining = (last_dword_index+1)*4
-    HexDumpAdapter(String("UnkData", lambda ctx: ((ctx.lastDwIndex+1)*4))),
+    ULInt32("lastDwIndex"),  # data remaining = (last_dword_index+1)*4
+    HexDumpAdapter(String("UnkData", lambda ctx: ((ctx.lastDwIndex + 1) * 4))),
     Terminator,
 )

--- a/pdbparse/fpo.py
+++ b/pdbparse/fpo.py
@@ -47,6 +47,7 @@ FPO_STRING_DATA = Struct(
     "Unk1" / Int32ul,
     "szDataLen" / Int32ul,
     "StringData" / Union(
+        0,
         "Data" / Bytes(lambda ctx: ctx._.szDataLen),
         "Strings" / RestreamData(
             Bytes(lambda ctx: ctx._.szDataLen),

--- a/pdbparse/gdata.py
+++ b/pdbparse/gdata.py
@@ -4,38 +4,43 @@ from io import BytesIO
 from construct import *
 from pdbparse.tpi import merge_subcon
 
-gsym = Struct("global",
-    ULInt16("leaf_type"),
-    Embed(Switch("data", lambda ctx: ctx.leaf_type,
-        {
-            0x110E : Struct("data_v3",
-                ULInt32("symtype"),
-                ULInt32("offset"),
-                ULInt16("segment"),
-                CString("name", encoding="utf8"),
-            
-            ),
-            0x1009 : Struct("data_v2",
-                ULInt32("symtype"),
-                ULInt32("offset"),
-                ULInt16("segment"),
-                PascalString("name", length_field=ULInt8("len")),
-            ),
-        },
-        default = Pass,
-    ))
-)
+gsym = Struct(
+    "global", ULInt16("leaf_type"),
+    Embed(
+        Switch(
+            "data",
+            lambda ctx: ctx.leaf_type,
+            {
+                0x110E:
+                Struct(
+                    "data_v3",
+                    ULInt32("symtype"),
+                    ULInt32("offset"),
+                    ULInt16("segment"),
+                    CString("name", encoding = "utf8"),
+                ),
+                0x1009:
+                Struct(
+                    "data_v2",
+                    ULInt32("symtype"),
+                    ULInt32("offset"),
+                    ULInt16("segment"),
+                    PascalString("name", length_field = ULInt8("len")),
+                ),
+            },
+            default = Pass,
+        )))
 
-GlobalsData = OptionalGreedyRange(
-    Tunnel(
-        PascalString("globals", length_field=ULInt16("len")),
-        gsym,
-    )
-)
+GlobalsData = OptionalGreedyRange(Tunnel(
+    PascalString("globals", length_field = ULInt16("len")),
+    gsym,
+))
+
 
 def parse(data):
     con = GlobalsData.parse(data)
     return con
+
 
 def parse_stream(stream):
     con = GlobalsData.parse_stream(stream)

--- a/pdbparse/gdata.py
+++ b/pdbparse/gdata.py
@@ -2,7 +2,7 @@
 
 from construct import *
 
-gsym = "global" / Struct(
+gsym = Struct(
     "leaf_type" / Int16ul, "data" / Switch(
         lambda ctx: ctx.leaf_type, {
             0x110E:
@@ -17,22 +17,38 @@ gsym = "global" / Struct(
                 "symtype" / Int32ul,
                 "offset" / Int32ul,
                 "segment" / Int16ul,
-                "name" / PascalString(lengthfield = "len" / Int8ul, encoding = "utf8"),
+                "name" / PascalString(lengthfield = "length" / Int8ul, encoding = "utf8"),
             ),
         }))
 
-GlobalsData = GreedyRange(
-    RestreamData(
-        "globals" / PascalString(lengthfield = "len" / Int16ul, encoding = "utf8"),
-        gsym,
+GlobalsData = "globals" / GreedyRange(
+    Struct(
+        "length" / Int16ul,
+        "symbol" / RestreamData(Bytes(lambda ctx: ctx.length), gsym),
     ))
 
 
 def parse(data):
     con = GlobalsData.parse(data)
-    return con
+    return merge_structures(con)
 
 
 def parse_stream(stream):
     con = GlobalsData.parse_stream(stream)
-    return con
+    return merge_structures(con)
+
+
+def merge_structures(con):
+    new_cons = []
+    for sym in con:
+        sym_dict = {'length': sym.length, 'leaf_type': sym.symbol.leaf_type}
+        if sym.symbol.data:
+            sym_dict.update({
+                'symtype': sym.symbol.data.symtype,
+                'offset': sym.symbol.data.offset,
+                'segment': sym.symbol.data.segment,
+                'name': sym.symbol.data.name
+            })
+        new_cons.append(Container(sym_dict))
+    result = ListContainer(new_cons)
+    return result

--- a/pdbparse/info.py
+++ b/pdbparse/info.py
@@ -1,23 +1,30 @@
 from construct import *
 from io import BytesIO
 
-_strarray = GreedyRange(CString("names", encoding="utf8"))
+_strarray = GreedyRange(CString("names", encoding = "utf8"))
+
 
 class StringArrayAdapter(Adapter):
-    def _encode(self,obj,context):
+
+    def _encode(self, obj, context):
         return _strarray._build(BytesIO(obj), context)
-    def _decode(self,obj,context):
+
+    def _decode(self, obj, context):
         return _strarray._parse(BytesIO(obj), context)
 
+
 def GUID(name):
-    return Struct(name,
+    return Struct(
+        name,
         ULInt32("Data1"),
         ULInt16("Data2"),
         ULInt16("Data3"),
         String("Data4", 8),
     )
 
-Info = Struct("Info",
+
+Info = Struct(
+    "Info",
     ULInt32("Version"),
     ULInt32("TimeDateStamp"),
     ULInt32("Age"),
@@ -26,9 +33,10 @@ Info = Struct("Info",
     StringArrayAdapter(MetaField("names", lambda ctx: ctx.cbNames)),
 )
 
+
 def parse_stream(stream):
     return Info.parse_stream(stream)
 
+
 def parse(data):
     return Info.parse(data)
-

--- a/pdbparse/info.py
+++ b/pdbparse/info.py
@@ -1,36 +1,35 @@
-from construct import *
 from io import BytesIO
 
-_strarray = GreedyRange(CString("names", encoding = "utf8"))
+from construct import *
+
+_strarray = "names" / GreedyRange(CString(encoding = "utf8"))
 
 
 class StringArrayAdapter(Adapter):
 
-    def _encode(self, obj, context):
-        return _strarray._build(BytesIO(obj), context)
+    def _encode(self, obj, context, path):
+        return _strarray._build(BytesIO(obj), context, path)
 
-    def _decode(self, obj, context):
-        return _strarray._parse(BytesIO(obj), context)
+    def _decode(self, obj, context, path):
+        return _strarray._parse(BytesIO(obj), context, path)
 
 
 def GUID(name):
-    return Struct(
-        name,
-        ULInt32("Data1"),
-        ULInt16("Data2"),
-        ULInt16("Data3"),
-        String("Data4", 8),
+    return name / Struct(
+        "Data1" / Int32ul,
+        "Data2" / Int16ul,
+        "Data3" / Int16ul,
+        "Data4" / PaddedString(8, encoding = "utf16"),
     )
 
 
-Info = Struct(
-    "Info",
-    ULInt32("Version"),
-    ULInt32("TimeDateStamp"),
-    ULInt32("Age"),
+Info = "Info" / Struct(
+    "Version" / Int32ul,
+    "TimeDateStamp" / Int32ul,
+    "Age" / Int32ul,
     GUID("GUID"),
-    ULInt32("cbNames"),
-    StringArrayAdapter(MetaField("names", lambda ctx: ctx.cbNames)),
+    "cbNames" / Int32ul,
+    "names" / StringArrayAdapter(Bytes(lambda ctx: ctx.cbNames)),
 )
 
 

--- a/pdbparse/omap.py
+++ b/pdbparse/omap.py
@@ -3,10 +3,9 @@
 from construct import *
 from bisect import bisect
 
-OMAP_ENTRY = Struct(
-    "OmapFromSrc",
-    ULInt32("From"),
-    ULInt32("To"),
+OMAP_ENTRY = "OmapFromSrc" / Struct(
+    "From" / Int32ul,
+    "To" / Int32ul,
 )
 
 OMAP_ENTRIES = GreedyRange(OMAP_ENTRY)

--- a/pdbparse/omap.py
+++ b/pdbparse/omap.py
@@ -3,14 +3,17 @@
 from construct import *
 from bisect import bisect
 
-OMAP_ENTRY = Struct("OmapFromSrc",
+OMAP_ENTRY = Struct(
+    "OmapFromSrc",
     ULInt32("From"),
     ULInt32("To"),
 )
 
 OMAP_ENTRIES = GreedyRange(OMAP_ENTRY)
 
+
 class Omap(object):
+
     def __init__(self, omapstream):
         self.omap = OMAP_ENTRIES.parse(omapstream)
 

--- a/pdbparse/pe.py
+++ b/pdbparse/pe.py
@@ -2,22 +2,21 @@
 
 from construct import *
 
-IMAGE_SECTION_HEADER = Struct(
-    "IMAGE_SECTION_HEADER",
-    String("Name", 8),
-    Union(
-        "Misc",
-        ULInt32("PhysicalAddress"),
-        ULInt32("VirtualSize"),
+IMAGE_SECTION_HEADER = "IMAGE_SECTION_HEADER" / Struct(
+    "Name" / PaddedString(8, encoding = "utf8"),
+    "Misc" / Union(
+        4,
+        "PhysicalAddress" / Int32ul,
+        "VirtualSize" / Int32ul,
     ),
-    ULInt32("VirtualAddress"),
-    ULInt32("SizeOfRawData"),
-    ULInt32("PointerToRawData"),
-    ULInt32("PointerToRelocations"),
-    ULInt32("PointerToLinenumbers"),
-    ULInt16("NumberOfRelocations"),
-    ULInt16("NumberOfLinenumbers"),
-    ULInt32("Characteristics"),
+    "VirtualAddress" / Int32ul,
+    "SizeOfRawData" / Int32ul,
+    "PointerToRawData" / Int32ul,
+    "PointerToRelocations" / Int32ul,
+    "PointerToLinenumbers" / Int32ul,
+    "NumberOfRelocations" / Int16ul,
+    "NumberOfLinenumbers" / Int16ul,
+    "Characteristics" / Int32ul,
 )
 
-Sections = OptionalGreedyRange(IMAGE_SECTION_HEADER)
+Sections = GreedyRange(IMAGE_SECTION_HEADER)

--- a/pdbparse/pe.py
+++ b/pdbparse/pe.py
@@ -5,7 +5,7 @@ from construct import *
 IMAGE_SECTION_HEADER = "IMAGE_SECTION_HEADER" / Struct(
     "Name" / PaddedString(8, encoding = "utf8"),
     "Misc" / Union(
-        4,
+        0,
         "PhysicalAddress" / Int32ul,
         "VirtualSize" / Int32ul,
     ),

--- a/pdbparse/pe.py
+++ b/pdbparse/pe.py
@@ -2,9 +2,11 @@
 
 from construct import *
 
-IMAGE_SECTION_HEADER = Struct("IMAGE_SECTION_HEADER",
+IMAGE_SECTION_HEADER = Struct(
+    "IMAGE_SECTION_HEADER",
     String("Name", 8),
-    Union("Misc",
+    Union(
+        "Misc",
         ULInt32("PhysicalAddress"),
         ULInt32("VirtualSize"),
     ),

--- a/pdbparse/peinfo.py
+++ b/pdbparse/peinfo.py
@@ -1,8 +1,10 @@
-import ntpath
 import binascii
+import ntpath
+import sys
 
 from pefile import PE, DEBUG_TYPE, DIRECTORY_ENTRY
-from pdbparse.dbgold import CV_RSDS_HEADER, CV_NB10_HEADER, DebugDirectoryType
+
+from pdbparse.dbgold import CV_RSDS_HEADER, CV_NB10_HEADER
 
 
 class PENoDebugDirectoryEntriesError(Exception):

--- a/pdbparse/peinfo.py
+++ b/pdbparse/peinfo.py
@@ -3,12 +3,14 @@ import binascii
 
 from pefile import PE, DEBUG_TYPE, DIRECTORY_ENTRY
 from pdbparse.dbgold import CV_RSDS_HEADER, CV_NB10_HEADER, DebugDirectoryType
-      
+
+
 class PENoDebugDirectoryEntriesError(Exception):
     pass
 
+
 def get_pe_debug_data(filename):
-    pe = PE(filename, fast_load=True)
+    pe = PE(filename, fast_load = True)
     # we prefer CodeView data to misc
     type = u'IMAGE_DEBUG_TYPE_CODEVIEW'
     dbgdata = get_debug_data(pe, DEBUG_TYPE[type])
@@ -19,6 +21,7 @@ def get_pe_debug_data(filename):
             type = None
     return dbgdata, type
 
+
 def get_external_codeview(filename):
     """
         Extract filename's debug CodeView information.
@@ -28,18 +31,19 @@ def get_external_codeview(filename):
             * (str) the GUID
             * (str) the pdb filename
     """
-    pe = PE(filename, fast_load=True)
+    pe = PE(filename, fast_load = True)
     dbgdata = get_debug_data(pe, DEBUG_TYPE[u'IMAGE_DEBUG_TYPE_CODEVIEW'])
     if dbgdata[:4] == b'RSDS':
-        (guid,filename) = get_rsds(dbgdata)
+        (guid, filename) = get_rsds(dbgdata)
     elif dbgdata[:4] == b'NB10':
-        (guid,filename) = get_nb10(dbgdata)
+        (guid, filename) = get_nb10(dbgdata)
     else:
         raise TypeError(u'Invalid CodeView signature: [%s]' % dbgdata[:4])
     guid = guid.upper()
     return guid, filename
 
-def get_debug_data(pe, type=DEBUG_TYPE[u'IMAGE_DEBUG_TYPE_CODEVIEW']):
+
+def get_debug_data(pe, type = DEBUG_TYPE[u'IMAGE_DEBUG_TYPE_CODEVIEW']):
     retval = None
     if not hasattr(pe, u'DIRECTORY_ENTRY_DEBUG'):
         # fast loaded - load directory
@@ -51,9 +55,10 @@ def get_debug_data(pe, type=DEBUG_TYPE[u'IMAGE_DEBUG_TYPE_CODEVIEW']):
             off = entry.struct.PointerToRawData
             size = entry.struct.SizeOfData
             if entry.struct.Type == type:
-                retval = pe.__data__[off:off+size]
+                retval = pe.__data__[off:off + size]
                 break
     return retval
+
 
 def get_dbg_fname(dbgdata):
     """
@@ -68,6 +73,7 @@ def get_dbg_fname(dbgdata):
     raw_filename = dbgstruct.Strings[0].decode('ascii')
     return ntpath.basename(raw_filename)
 
+
 def get_rsds(dbgdata):
     """
         Parse the RSDS header using construct.
@@ -78,12 +84,11 @@ def get_rsds(dbgdata):
             * (str) the pdb filename
     """
     dbg = CV_RSDS_HEADER.parse(dbgdata)
-    guidstr = u"%08x%04x%04x%s%x" % (
-        dbg.GUID.Data1, dbg.GUID.Data2, dbg.GUID.Data3,  
-        binascii.hexlify(dbg.GUID.Data4).decode('ascii'),
-        dbg.Age)
+    guidstr = u"%08x%04x%04x%s%x" % (dbg.GUID.Data1, dbg.GUID.Data2, dbg.GUID.Data3, binascii.hexlify(
+        dbg.GUID.Data4).decode('ascii'), dbg.Age)
     filename = ntpath.basename(dbg.Filename.decode('ascii'))
-    return guidstr,filename
+    return guidstr, filename
+
 
 def get_nb10(dbgdata):
     """
@@ -97,7 +102,7 @@ def get_nb10(dbgdata):
     dbg = CV_NB10_HEADER.parse(dbgdata)
     guidstr = u"%x%x" % (dbg.Timestamp, dbg.Age)
     filename = ntpath.basename(dbg.Filename.decode('ascii'))
-    return guidstr,filename
+    return guidstr, filename
 
 
 def get_pe_guid(filename):
@@ -109,12 +114,9 @@ def get_pe_guid(filename):
             * (str) PE GUID
     """
     try:
-        pe = PE(filename, fast_load=True)
+        pe = PE(filename, fast_load = True)
     except IOError as e:
-        print (e)
+        print(e)
         sys.exit(-1)
-    guidstr = "%x%x" % (pe.FILE_HEADER.TimeDateStamp,
-                        pe.OPTIONAL_HEADER.SizeOfImage)
+    guidstr = "%x%x" % (pe.FILE_HEADER.TimeDateStamp, pe.OPTIONAL_HEADER.SizeOfImage)
     return guidstr
-
-

--- a/pdbparse/postfix_eval.py
+++ b/pdbparse/postfix_eval.py
@@ -8,11 +8,13 @@ from operator import inv
 global vars
 vars = {}
 
-def assign(a,b):
+
+def assign(a, b):
     global vars
-    if not isinstance(a,str) or not a.startswith("$"):
+    if not isinstance(a, str) or not a.startswith("$"):
         raise ValueError("Cannot assign to a constant")
     vars[a] = b
+
 
 binary_ops = {
     "+": add,
@@ -31,12 +33,13 @@ binary_ops = {
 # ^ means "dereference". In the airbag unit tests, this is accompanied by
 # a memory region that can deal with dereferencing addresses (presumably).
 # Their test uses FakeMemoryRegion, which appears to just return x+1 for
-# any pointer x that is dereferenced. So we use lambda x: x+1 as a 
+# any pointer x that is dereferenced. So we use lambda x: x+1 as a
 # placeholder.
 unary_ops = {
     "~": inv,
-    "^": lambda x: x+1, 
+    "^": lambda x: x + 1,
 }
+
 
 def evaluate(pfstr):
     global vars
@@ -49,85 +52,97 @@ def evaluate(pfstr):
             except IndexError:
                 raise ValueError("Not enough values on the stack for requested operation")
 
-            if isinstance(b,str) and (b.startswith("$") or b.startswith(".")):
-                try: b = vars[b]
-                except KeyError: raise ValueError("Name %s referenced before assignment" % b)
-            
-            assign(a,b)
+            if isinstance(b, str) and (b.startswith("$") or b.startswith(".")):
+                try:
+                    b = vars[b]
+                except KeyError:
+                    raise ValueError("Name %s referenced before assignment" % b)
+
+            assign(a, b)
         elif tok in binary_ops:
             try:
                 b = stack.pop()
                 a = stack.pop()
             except IndexError:
                 raise ValueError("Not enough values on the stack for requested operation")
-            
-            if isinstance(a,str) and (a.startswith("$") or a.startswith(".")):
-                try: a = vars[a]
-                except KeyError: raise ValueError("Name %s referenced before assignment" % a)
-            if isinstance(b,str) and (b.startswith("$") or b.startswith(".")):
-                try: b = vars[b]
-                except KeyError: raise ValueError("Name %s referenced before assignment" % b)
 
-            stack.append(binary_ops[tok](a,b))
+            if isinstance(a, str) and (a.startswith("$") or a.startswith(".")):
+                try:
+                    a = vars[a]
+                except KeyError:
+                    raise ValueError("Name %s referenced before assignment" % a)
+            if isinstance(b, str) and (b.startswith("$") or b.startswith(".")):
+                try:
+                    b = vars[b]
+                except KeyError:
+                    raise ValueError("Name %s referenced before assignment" % b)
+
+            stack.append(binary_ops[tok](a, b))
         elif tok in unary_ops:
             try:
                 a = stack.pop()
             except IndexError:
                 raise ValueError("Not enough values on the stack for requested operation")
 
-            if isinstance(a,str) and (a.startswith("$") or a.startswith(".")):
-                try: a = vars[a]
-                except KeyError: raise ValueError("Name %s referenced before assignment" % a)
-            
+            if isinstance(a, str) and (a.startswith("$") or a.startswith(".")):
+                try:
+                    a = vars[a]
+                except KeyError:
+                    raise ValueError("Name %s referenced before assignment" % a)
+
             stack.append(unary_ops[tok](a))
         elif tok.startswith("$") or tok.startswith("."):
             stack.append(tok)
         else:
-            stack.append(int(tok,0))
+            stack.append(int(tok, 0))
     if stack:
         raise ValueError("Values remain on the stack after processing")
 
+
 if __name__ == "__main__":
     pfstrs = [
-        ("$T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + = $L $T0 .cbSavedRegs - = $P $T0 8 + .cbParams + =", True),
-        ("$T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + = $L $T0 .cbSavedRegs - = $P $T0 8 + .cbParams + = $ebx $T0 28 - ^ =", True),
-        ("$T0 $ebp = $T2 $esp = $T1 .raSearchStart = $eip $T1 ^ = $ebp $T0 = $esp $T1 4 + = $L $T0 .cbSavedRegs - = $P $T1 4 + .cbParams + = $ebx $T0 28 - ^ =", True),
+        ("$T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + = $L $T0 .cbSavedRegs - = $P $T0 8 + .cbParams + =",
+         True),
+        ("$T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + = $L $T0 .cbSavedRegs - = $P $T0 8 + .cbParams + = $ebx $T0 28 - ^ =",
+         True),
+        ("$T0 $ebp = $T2 $esp = $T1 .raSearchStart = $eip $T1 ^ = $ebp $T0 = $esp $T1 4 + = $L $T0 .cbSavedRegs - = $P $T1 4 + .cbParams + = $ebx $T0 28 - ^ =",
+         True),
     ]
-              
-    vars["$ebp"] = 0xbfff0010;
-    vars["$eip"] = 0x10000000;
-    vars["$esp"] = 0xbfff0000;
-    vars[".cbSavedRegs"] = 4;
-    vars[".cbParams"] = 4;
-    vars[".raSearchStart"] = 0xbfff0020;
 
-    for (test,should_succeed) in pfstrs:
+    vars["$ebp"] = 0xbfff0010
+    vars["$eip"] = 0x10000000
+    vars["$esp"] = 0xbfff0000
+    vars[".cbSavedRegs"] = 4
+    vars[".cbParams"] = 4
+    vars[".raSearchStart"] = 0xbfff0020
+
+    for (test, should_succeed) in pfstrs:
         try:
             evaluate(test)
             if len(repr(test)) > 50:
                 test = test[:50] + "[...]"
             if not should_succeed:
-                print ('Test %-60s FAILED.' % repr(test))
+                print('Test %-60s FAILED.' % repr(test))
             else:
-                print ('Test %-60s PASSED.' % repr(test))
+                print('Test %-60s PASSED.' % repr(test))
         except ValueError:
             if should_succeed:
-                print ('Test %-60s FAILED.' % repr(test))
+                print('Test %-60s FAILED.' % repr(test))
             else:
-                print ('Test %-60s PASSED.' % repr(test))
-    
+                print('Test %-60s PASSED.' % repr(test))
+
     validate_data_1 = {}
-    validate_data_1["$T0"]  = 0xbfff0012;
-    validate_data_1["$T1"]  = 0xbfff0020;
-    validate_data_1["$T2"]  = 0xbfff0019;
-    validate_data_1["$eip"] = 0xbfff0021;
-    validate_data_1["$ebp"] = 0xbfff0012;
-    validate_data_1["$esp"] = 0xbfff0024;
-    validate_data_1["$L"]   = 0xbfff000e;
-    validate_data_1["$P"]   = 0xbfff0028;
-    validate_data_1["$ebx"] = 0xbffefff7;
-    validate_data_1[".cbSavedRegs"] = 4;
-    validate_data_1[".cbParams"] = 4;
+    validate_data_1["$T0"] = 0xbfff0012
+    validate_data_1["$T1"] = 0xbfff0020
+    validate_data_1["$T2"] = 0xbfff0019
+    validate_data_1["$eip"] = 0xbfff0021
+    validate_data_1["$ebp"] = 0xbfff0012
+    validate_data_1["$esp"] = 0xbfff0024
+    validate_data_1["$L"] = 0xbfff000e
+    validate_data_1["$P"] = 0xbfff0028
+    validate_data_1["$ebx"] = 0xbffefff7
+    validate_data_1[".cbSavedRegs"] = 4
+    validate_data_1[".cbParams"] = 4
 
     for k in validate_data_1:
         assert vars[k] == validate_data_1[k]
@@ -135,60 +150,60 @@ if __name__ == "__main__":
     vars = {}
 
     validate_data_0 = {}
-    validate_data_0["$rAdd"]   = 8;
-    validate_data_0["$rAdd2"]  = 4;
-    validate_data_0["$rSub"]   = 3;
-    validate_data_0["$rMul"]   = 54;
-    validate_data_0["$rDivQ"]  = 1;
-    validate_data_0["$rDivM"]  = 3;
-    validate_data_0["$rDeref"] = 10;
+    validate_data_0["$rAdd"] = 8
+    validate_data_0["$rAdd2"] = 4
+    validate_data_0["$rSub"] = 3
+    validate_data_0["$rMul"] = 54
+    validate_data_0["$rDivQ"] = 1
+    validate_data_0["$rDivM"] = 3
+    validate_data_0["$rDeref"] = 10
 
     pfstrs = [
-        ( "$rAdd 2 2 + =",     True ),   # $rAdd = 2 + 2 = 4
-        ( "$rAdd $rAdd 2 + =", True ),   # $rAdd = $rAdd + 2 = 6
-        ( "$rAdd 2 $rAdd + =", True ),   # $rAdd = 2 + $rAdd = 8
-        ( "99",                False ),  # put some junk on the stack...
-        ( "$rAdd2 2 2 + =",    True ),   # ...and make sure things still work
-        ( "$rAdd2\t2\n2 + =",  True ),   # same but with different whitespace
-        ( "$rAdd2 2 2 + = ",   True ),   # trailing whitespace
-        ( " $rAdd2 2 2 + =",   True ),   # leading whitespace
-        ( "$rAdd2  2 2 +   =", True ),   # extra whitespace
-        ( "$T0 2 = +",         False ),  # too few operands for add
-        ( "2 + =",             False ),  # too few operands for add
-        ( "2 +",               False ),  # too few operands for add
-        ( "+",                 False ),  # too few operands for add
-        ( "^",                 False ),  # too few operands for dereference
-        ( "=",                 False ),  # too few operands for assignment
-        ( "2 =",               False ),  # too few operands for assignment
-        ( "2 2 + =",           False ),  # too few operands for assignment
-        ( "2 2 =",             False ),  # can't assign into a literal
-        ( "k 2 =",             False ),  # can't assign into a constant
-        ( "2",                 False ),  # leftover data on stack
-        ( "2 2 +",             False ),  # leftover data on stack
-        ( "$rAdd",             False ),  # leftover data on stack
-        ( "0 $T1 0 0 + =",     False ),  # leftover data on stack
-        ( "$T2 $T2 2 + =",     False ),  # can't operate on an undefined value
-        ( "$rMul 9 6 * =",     True ),   # $rMul = 9 * 6 = 54
-        ( "$rSub 9 6 - =",     True ),   # $rSub = 9 - 6 = 3
-        ( "$rDivQ 9 6 / =",    True ),   # $rDivQ = 9 / 6 = 1
-        ( "$rDivM 9 6 % =",    True ),   # $rDivM = 9 % 6 = 3
-        ( "$rDeref 9 ^ =",     True )    # $rDeref = ^9 = 10 (FakeMemoryRegion)
+        ("$rAdd 2 2 + =", True),  # $rAdd = 2 + 2 = 4
+        ("$rAdd $rAdd 2 + =", True),  # $rAdd = $rAdd + 2 = 6
+        ("$rAdd 2 $rAdd + =", True),  # $rAdd = 2 + $rAdd = 8
+        ("99", False),  # put some junk on the stack...
+        ("$rAdd2 2 2 + =", True),  # ...and make sure things still work
+        ("$rAdd2\t2\n2 + =", True),  # same but with different whitespace
+        ("$rAdd2 2 2 + = ", True),  # trailing whitespace
+        (" $rAdd2 2 2 + =", True),  # leading whitespace
+        ("$rAdd2  2 2 +   =", True),  # extra whitespace
+        ("$T0 2 = +", False),  # too few operands for add
+        ("2 + =", False),  # too few operands for add
+        ("2 +", False),  # too few operands for add
+        ("+", False),  # too few operands for add
+        ("^", False),  # too few operands for dereference
+        ("=", False),  # too few operands for assignment
+        ("2 =", False),  # too few operands for assignment
+        ("2 2 + =", False),  # too few operands for assignment
+        ("2 2 =", False),  # can't assign into a literal
+        ("k 2 =", False),  # can't assign into a constant
+        ("2", False),  # leftover data on stack
+        ("2 2 +", False),  # leftover data on stack
+        ("$rAdd", False),  # leftover data on stack
+        ("0 $T1 0 0 + =", False),  # leftover data on stack
+        ("$T2 $T2 2 + =", False),  # can't operate on an undefined value
+        ("$rMul 9 6 * =", True),  # $rMul = 9 * 6 = 54
+        ("$rSub 9 6 - =", True),  # $rSub = 9 - 6 = 3
+        ("$rDivQ 9 6 / =", True),  # $rDivQ = 9 / 6 = 1
+        ("$rDivM 9 6 % =", True),  # $rDivM = 9 % 6 = 3
+        ("$rDeref 9 ^ =", True)  # $rDeref = ^9 = 10 (FakeMemoryRegion)
     ]
 
-    for (test,should_succeed) in pfstrs:
+    for (test, should_succeed) in pfstrs:
         try:
             evaluate(test)
             if len(repr(test)) > 50:
                 test = test[:50] + "[...]"
             if not should_succeed:
-                print ('Test %-60s FAILED.' % repr(test))
+                print('Test %-60s FAILED.' % repr(test))
             else:
-                print ('Test %-60s PASSED.' % repr(test))
+                print('Test %-60s PASSED.' % repr(test))
         except ValueError:
             if should_succeed:
-                print ('Test %-60s FAILED.' % repr(test))
+                print('Test %-60s FAILED.' % repr(test))
             else:
-                print ('Test %-60s PASSED.' % repr(test))
+                print('Test %-60s PASSED.' % repr(test))
 
     for k in validate_data_0:
         assert vars[k] == validate_data_0[k]

--- a/pdbparse/postfix_eval.py
+++ b/pdbparse/postfix_eval.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-from pprint import pprint
-
-from operator import add, sub, mul, div, mod, pow, and_, or_, lshift, rshift, xor
+from operator import add, sub, mul, mod, itruediv, pow, and_, or_, lshift, rshift
 from operator import inv
 
 global vars
@@ -19,7 +17,7 @@ def assign(a, b):
 binary_ops = {
     "+": add,
     "-": sub,
-    "/": div,
+    "/": itruediv,
     "*": mul,
     "%": mod,
     "**": pow,

--- a/pdbparse/symlookup.py
+++ b/pdbparse/symlookup.py
@@ -1,33 +1,37 @@
 import pdbparse
 import os
-from operator import itemgetter,attrgetter
+from operator import itemgetter, attrgetter
 from bisect import bisect_right
 from pdbparse.undecorate import undecorate
 from itertools import islice, count
 
+
 class DummyOmap(object):
+
     def remap(self, addr):
         return addr
 
+
 class Lookup(object):
+
     def __init__(self, mods):
         self.addrs = {}
         self._cache = {}
 
         not_found = []
 
-        for pdbname,base in mods:
+        for pdbname, base in mods:
             pdbbase = ".".join(os.path.basename(pdbname).split('.')[:-1])
             if not os.path.exists(pdbname):
-                print ("WARN: %s not found" % pdbname)
-                not_found.append( (base, pdbbase) )
+                print("WARN: %s not found" % pdbname)
+                not_found.append((base, pdbbase))
                 continue
 
             #print ("Loading symbols for %s..." % pdbbase)
             try:
                 # Do this the hard way to avoid having to load
                 # the types stream in mammoth PDB files
-                pdb = pdbparse.parse(pdbname, fast_load=True)
+                pdb = pdbparse.parse(pdbname, fast_load = True)
                 pdb.STREAM_DBI.load()
                 pdb._update_names()
                 pdb.STREAM_GSYM = pdb.STREAM_GSYM.reload()
@@ -60,49 +64,49 @@ class Lookup(object):
             if not hasattr(gsyms, 'globals'):
                 gsyms.globals = []
 
-            last_sect = max(sects, key=attrgetter('VirtualAddress'))
+            last_sect = max(sects, key = attrgetter('VirtualAddress'))
             limit = base + last_sect.VirtualAddress + last_sect.Misc.VirtualSize
 
-            self.addrs[base,limit] = {}
-            self.addrs[base,limit]['name'] = pdbbase
-            self.addrs[base,limit]['addrs'] = []
+            self.addrs[base, limit] = {}
+            self.addrs[base, limit]['name'] = pdbbase
+            self.addrs[base, limit]['addrs'] = []
             for sym in gsyms.globals:
                 if not hasattr(sym, 'offset'): continue
                 off = sym.offset
                 try:
-                    virt_base = sects[sym.segment-1].VirtualAddress
+                    virt_base = sects[sym.segment - 1].VirtualAddress
                 except IndexError:
                     continue
 
-                mapped = omap.remap(off+virt_base) + base
-                self.addrs[base,limit]['addrs'].append((mapped,sym.name))
+                mapped = omap.remap(off + virt_base) + base
+                self.addrs[base, limit]['addrs'].append((mapped, sym.name))
 
-            self.addrs[base,limit]['addrs'].sort(key=itemgetter(0))
+            self.addrs[base, limit]['addrs'].sort(key = itemgetter(0))
 
         self.locs = {}
         self.names = {}
-        for base,limit in self.addrs:
-            mod = self.addrs[base,limit]['name']
-            symbols = self.addrs[base,limit]['addrs']
-            self.locs[base,limit]  = [a[0] for a in symbols]
-            self.names[base,limit] = [a[1] for a in symbols]
+        for base, limit in self.addrs:
+            mod = self.addrs[base, limit]['name']
+            symbols = self.addrs[base, limit]['addrs']
+            self.locs[base, limit] = [a[0] for a in symbols]
+            self.names[base, limit] = [a[1] for a in symbols]
 
     def lookup(self, loc):
         if loc in self._cache:
             return self._cache[loc]
 
-        for base,limit in self.addrs:
+        for base, limit in self.addrs:
             if loc >= base and loc < limit:
-                mod = self.addrs[base,limit]['name']
-                symbols = self.addrs[base,limit]['addrs']
-                locs  = self.locs[base,limit]
-                names = self.names[base,limit] 
+                mod = self.addrs[base, limit]['name']
+                symbols = self.addrs[base, limit]['addrs']
+                locs = self.locs[base, limit]
+                names = self.names[base, limit]
                 idx = bisect_right(locs, loc) - 1
                 diff = loc - locs[idx]
                 if diff:
-                    ret = "%s!%s+%#x" % (mod,names[idx],diff)
+                    ret = "%s!%s+%#x" % (mod, names[idx], diff)
                 else:
-                    ret = "%s!%s" % (mod,names[idx])
+                    ret = "%s!%s" % (mod, names[idx])
                 self._cache[loc] = ret
                 return ret
         return "unknown"

--- a/pdbparse/symlookup.py
+++ b/pdbparse/symlookup.py
@@ -1,9 +1,8 @@
-import pdbparse
 import os
-from operator import itemgetter, attrgetter
 from bisect import bisect_right
-from pdbparse.undecorate import undecorate
-from itertools import islice, count
+from operator import itemgetter, attrgetter
+
+import pdbparse
 
 
 class DummyOmap(object):
@@ -27,7 +26,7 @@ class Lookup(object):
                 not_found.append((base, pdbbase))
                 continue
 
-            #print ("Loading symbols for %s..." % pdbbase)
+            # print ("Loading symbols for %s..." % pdbbase)
             try:
                 # Do this the hard way to avoid having to load
                 # the types stream in mammoth PDB files
@@ -47,7 +46,7 @@ class Lookup(object):
 
             except AttributeError as e:
                 pass
-            #except Exception as e:
+            # except Exception as e:
             #    print ("WARN: error %s parsing %s, skipping" % (e,pdbbase))
             #    not_found.append( (base, pdbbase) )
             #    continue
@@ -71,7 +70,8 @@ class Lookup(object):
             self.addrs[base, limit]['name'] = pdbbase
             self.addrs[base, limit]['addrs'] = []
             for sym in gsyms.globals:
-                if not hasattr(sym, 'offset'): continue
+                if not hasattr(sym, 'offset'):
+                    continue
                 off = sym.offset
                 try:
                     virt_base = sects[sym.segment - 1].VirtualAddress

--- a/pdbparse/tpi.py
+++ b/pdbparse/tpi.py
@@ -5,7 +5,6 @@ from io import BytesIO
 
 from construct import *
 
-
 # For each metatype, which attributes are references
 # to another type
 type_refs = {
@@ -47,698 +46,618 @@ type_refs = {
 # call the function with the ** operator
 base_types = {
     #      Special Types
-
-    "T_NOTYPE"        : 0x0000,   # uncharacterized type (no type)
-    "T_ABS"           : 0x0001,   # absolute symbol
-    "T_SEGMENT"       : 0x0002,   # segment type
-    "T_VOID"          : 0x0003,   # void
-    "T_HRESULT"       : 0x0008,   # OLE/COM HRESULT
-    "T_32PHRESULT"    : 0x0408,   # OLE/COM HRESULT __ptr32 *
-    "T_64PHRESULT"    : 0x0608,   # OLE/COM HRESULT __ptr64 *
-
-    "T_PVOID"         : 0x0103,   # near pointer to void
-    "T_PFVOID"        : 0x0203,   # far pointer to void
-    "T_PHVOID"        : 0x0303,   # huge pointer to void
-    "T_32PVOID"       : 0x0403,   # 32 bit pointer to void
-    "T_32PFVOID"      : 0x0503,   # 16:32 pointer to void
-    "T_64PVOID"       : 0x0603,   # 64 bit pointer to void
-    "T_CURRENCY"      : 0x0004,   # BASIC 8 byte currency value
-    "T_NBASICSTR"     : 0x0005,   # Near BASIC string
-    "T_FBASICSTR"     : 0x0006,   # Far BASIC string
-    "T_NOTTRANS"      : 0x0007,   # type not translated by cvpack
-    "T_BIT"           : 0x0060,   # bit
-    "T_PASCHAR"       : 0x0061,   # Pascal CHAR
-    "T_BOOL32FF"      : 0x0062,   # 32-bit BOOL where true is 0xffffffff
-
-
-#      Character types
-
-    "T_CHAR"          : 0x0010,   # 8 bit signed
-    "T_PCHAR"         : 0x0110,   # 16 bit pointer to 8 bit signed
-    "T_PFCHAR"        : 0x0210,   # 16:16 far pointer to 8 bit signed
-    "T_PHCHAR"        : 0x0310,   # 16:16 huge pointer to 8 bit signed
-    "T_32PCHAR"       : 0x0410,   # 32 bit pointer to 8 bit signed
-    "T_32PFCHAR"      : 0x0510,   # 16:32 pointer to 8 bit signed
-    "T_64PCHAR"       : 0x0610,   # 64 bit pointer to 8 bit signed
-
-    "T_UCHAR"         : 0x0020,   # 8 bit unsigned
-    "T_PUCHAR"        : 0x0120,   # 16 bit pointer to 8 bit unsigned
-    "T_PFUCHAR"       : 0x0220,   # 16:16 far pointer to 8 bit unsigned
-    "T_PHUCHAR"       : 0x0320,   # 16:16 huge pointer to 8 bit unsigned
-    "T_32PUCHAR"      : 0x0420,   # 32 bit pointer to 8 bit unsigned
-    "T_32PFUCHAR"     : 0x0520,   # 16:32 pointer to 8 bit unsigned
-    "T_64PUCHAR"      : 0x0620,   # 64 bit pointer to 8 bit unsigned
-
-
-#      really a character types
-
-    "T_RCHAR"         : 0x0070,   # really a char
-    "T_PRCHAR"        : 0x0170,   # 16 bit pointer to a real char
-    "T_PFRCHAR"       : 0x0270,   # 16:16 far pointer to a real char
-    "T_PHRCHAR"       : 0x0370,   # 16:16 huge pointer to a real char
-    "T_32PRCHAR"      : 0x0470,   # 32 bit pointer to a real char
-    "T_32PFRCHAR"     : 0x0570,   # 16:32 pointer to a real char
-    "T_64PRCHAR"      : 0x0670,   # 64 bit pointer to a real char
-
-
-#      really a wide character types
-
-    "T_WCHAR"         : 0x0071,   # wide char
-    "T_PWCHAR"        : 0x0171,   # 16 bit pointer to a wide char
-    "T_PFWCHAR"       : 0x0271,   # 16:16 far pointer to a wide char
-    "T_PHWCHAR"       : 0x0371,   # 16:16 huge pointer to a wide char
-    "T_32PWCHAR"      : 0x0471,   # 32 bit pointer to a wide char
-    "T_32PFWCHAR"     : 0x0571,   # 16:32 pointer to a wide char
-    "T_64PWCHAR"      : 0x0671,   # 64 bit pointer to a wide char
-
-#      really a 16-bit unicode char
-
-    "T_CHAR16"         : 0x007a,   # 16-bit unicode char
-    "T_PCHAR16"        : 0x017a,   # 16 bit pointer to a 16-bit unicode char
-    "T_PFCHAR16"       : 0x027a,   # 16:16 far pointer to a 16-bit unicode char
-    "T_PHCHAR16"       : 0x037a,   # 16:16 huge pointer to a 16-bit unicode char
-    "T_32PCHAR16"      : 0x047a,   # 32 bit pointer to a 16-bit unicode char
-    "T_32PFCHAR16"     : 0x057a,   # 16:32 pointer to a 16-bit unicode char
-    "T_64PCHAR16"      : 0x067a,   # 64 bit pointer to a 16-bit unicode char
-
-#      really a 32-bit unicode char
-
-    "T_CHAR32"         : 0x007b,   # 32-bit unicode char
-    "T_PCHAR32"        : 0x017b,   # 16 bit pointer to a 32-bit unicode char
-    "T_PFCHAR32"       : 0x027b,   # 16:16 far pointer to a 32-bit unicode char
-    "T_PHCHAR32"       : 0x037b,   # 16:16 huge pointer to a 32-bit unicode char
-    "T_32PCHAR32"      : 0x047b,   # 32 bit pointer to a 32-bit unicode char
-    "T_32PFCHAR32"     : 0x057b,   # 16:32 pointer to a 32-bit unicode char
-    "T_64PCHAR32"      : 0x067b,   # 64 bit pointer to a 32-bit unicode char
-
-#      8 bit int types
-
-    "T_INT1"          : 0x0068,   # 8 bit signed int
-    "T_PINT1"         : 0x0168,   # 16 bit pointer to 8 bit signed int
-    "T_PFINT1"        : 0x0268,   # 16:16 far pointer to 8 bit signed int
-    "T_PHINT1"        : 0x0368,   # 16:16 huge pointer to 8 bit signed int
-    "T_32PINT1"       : 0x0468,   # 32 bit pointer to 8 bit signed int
-    "T_32PFINT1"      : 0x0568,   # 16:32 pointer to 8 bit signed int
-    "T_64PINT1"       : 0x0668,   # 64 bit pointer to 8 bit signed int
-
-    "T_UINT1"         : 0x0069,   # 8 bit unsigned int
-    "T_PUINT1"        : 0x0169,   # 16 bit pointer to 8 bit unsigned int
-    "T_PFUINT1"       : 0x0269,   # 16:16 far pointer to 8 bit unsigned int
-    "T_PHUINT1"       : 0x0369,   # 16:16 huge pointer to 8 bit unsigned int
-    "T_32PUINT1"      : 0x0469,   # 32 bit pointer to 8 bit unsigned int
-    "T_32PFUINT1"     : 0x0569,   # 16:32 pointer to 8 bit unsigned int
-    "T_64PUINT1"      : 0x0669,   # 64 bit pointer to 8 bit unsigned int
-
-
-#      16 bit short types
-
-    "T_SHORT"         : 0x0011,   # 16 bit signed
-    "T_PSHORT"        : 0x0111,   # 16 bit pointer to 16 bit signed
-    "T_PFSHORT"       : 0x0211,   # 16:16 far pointer to 16 bit signed
-    "T_PHSHORT"       : 0x0311,   # 16:16 huge pointer to 16 bit signed
-    "T_32PSHORT"      : 0x0411,   # 32 bit pointer to 16 bit signed
-    "T_32PFSHORT"     : 0x0511,   # 16:32 pointer to 16 bit signed
-    "T_64PSHORT"      : 0x0611,   # 64 bit pointer to 16 bit signed
-
-    "T_USHORT"        : 0x0021,   # 16 bit unsigned
-    "T_PUSHORT"       : 0x0121,   # 16 bit pointer to 16 bit unsigned
-    "T_PFUSHORT"      : 0x0221,   # 16:16 far pointer to 16 bit unsigned
-    "T_PHUSHORT"      : 0x0321,   # 16:16 huge pointer to 16 bit unsigned
-    "T_32PUSHORT"     : 0x0421,   # 32 bit pointer to 16 bit unsigned
-    "T_32PFUSHORT"    : 0x0521,   # 16:32 pointer to 16 bit unsigned
-    "T_64PUSHORT"     : 0x0621,   # 64 bit pointer to 16 bit unsigned
-
-
-#      16 bit int types
-
-    "T_INT2"          : 0x0072,   # 16 bit signed int
-    "T_PINT2"         : 0x0172,   # 16 bit pointer to 16 bit signed int
-    "T_PFINT2"        : 0x0272,   # 16:16 far pointer to 16 bit signed int
-    "T_PHINT2"        : 0x0372,   # 16:16 huge pointer to 16 bit signed int
-    "T_32PINT2"       : 0x0472,   # 32 bit pointer to 16 bit signed int
-    "T_32PFINT2"      : 0x0572,   # 16:32 pointer to 16 bit signed int
-    "T_64PINT2"       : 0x0672,   # 64 bit pointer to 16 bit signed int
-
-    "T_UINT2"         : 0x0073,   # 16 bit unsigned int
-    "T_PUINT2"        : 0x0173,   # 16 bit pointer to 16 bit unsigned int
-    "T_PFUINT2"       : 0x0273,   # 16:16 far pointer to 16 bit unsigned int
-    "T_PHUINT2"       : 0x0373,   # 16:16 huge pointer to 16 bit unsigned int
-    "T_32PUINT2"      : 0x0473,   # 32 bit pointer to 16 bit unsigned int
-    "T_32PFUINT2"     : 0x0573,   # 16:32 pointer to 16 bit unsigned int
-    "T_64PUINT2"      : 0x0673,   # 64 bit pointer to 16 bit unsigned int
-
-
-#      32 bit long types
-
-    "T_LONG"          : 0x0012,   # 32 bit signed
-    "T_ULONG"         : 0x0022,   # 32 bit unsigned
-    "T_PLONG"         : 0x0112,   # 16 bit pointer to 32 bit signed
-    "T_PULONG"        : 0x0122,   # 16 bit pointer to 32 bit unsigned
-    "T_PFLONG"        : 0x0212,   # 16:16 far pointer to 32 bit signed
-    "T_PFULONG"       : 0x0222,   # 16:16 far pointer to 32 bit unsigned
-    "T_PHLONG"        : 0x0312,   # 16:16 huge pointer to 32 bit signed
-    "T_PHULONG"       : 0x0322,   # 16:16 huge pointer to 32 bit unsigned
-
-    "T_32PLONG"       : 0x0412,   # 32 bit pointer to 32 bit signed
-    "T_32PULONG"      : 0x0422,   # 32 bit pointer to 32 bit unsigned
-    "T_32PFLONG"      : 0x0512,   # 16:32 pointer to 32 bit signed
-    "T_32PFULONG"     : 0x0522,   # 16:32 pointer to 32 bit unsigned
-    "T_64PLONG"       : 0x0612,   # 64 bit pointer to 32 bit signed
-    "T_64PULONG"      : 0x0622,   # 64 bit pointer to 32 bit unsigned
-
-
-#      32 bit int types
-
-    "T_INT4"          : 0x0074,   # 32 bit signed int
-    "T_PINT4"         : 0x0174,   # 16 bit pointer to 32 bit signed int
-    "T_PFINT4"        : 0x0274,   # 16:16 far pointer to 32 bit signed int
-    "T_PHINT4"        : 0x0374,   # 16:16 huge pointer to 32 bit signed int
-    "T_32PINT4"       : 0x0474,   # 32 bit pointer to 32 bit signed int
-    "T_32PFINT4"      : 0x0574,   # 16:32 pointer to 32 bit signed int
-    "T_64PINT4"       : 0x0674,   # 64 bit pointer to 32 bit signed int
-
-    "T_UINT4"         : 0x0075,   # 32 bit unsigned int
-    "T_PUINT4"        : 0x0175,   # 16 bit pointer to 32 bit unsigned int
-    "T_PFUINT4"       : 0x0275,   # 16:16 far pointer to 32 bit unsigned int
-    "T_PHUINT4"       : 0x0375,   # 16:16 huge pointer to 32 bit unsigned int
-    "T_32PUINT4"      : 0x0475,   # 32 bit pointer to 32 bit unsigned int
-    "T_32PFUINT4"     : 0x0575,   # 16:32 pointer to 32 bit unsigned int
-    "T_64PUINT4"      : 0x0675,   # 64 bit pointer to 32 bit unsigned int
-
-
-#      64 bit quad types
-
-    "T_QUAD"          : 0x0013,   # 64 bit signed
-    "T_PQUAD"         : 0x0113,   # 16 bit pointer to 64 bit signed
-    "T_PFQUAD"        : 0x0213,   # 16:16 far pointer to 64 bit signed
-    "T_PHQUAD"        : 0x0313,   # 16:16 huge pointer to 64 bit signed
-    "T_32PQUAD"       : 0x0413,   # 32 bit pointer to 64 bit signed
-    "T_32PFQUAD"      : 0x0513,   # 16:32 pointer to 64 bit signed
-    "T_64PQUAD"       : 0x0613,   # 64 bit pointer to 64 bit signed
-
-    "T_UQUAD"         : 0x0023,   # 64 bit unsigned
-    "T_PUQUAD"        : 0x0123,   # 16 bit pointer to 64 bit unsigned
-    "T_PFUQUAD"       : 0x0223,   # 16:16 far pointer to 64 bit unsigned
-    "T_PHUQUAD"       : 0x0323,   # 16:16 huge pointer to 64 bit unsigned
-    "T_32PUQUAD"      : 0x0423,   # 32 bit pointer to 64 bit unsigned
-    "T_32PFUQUAD"     : 0x0523,   # 16:32 pointer to 64 bit unsigned
-    "T_64PUQUAD"      : 0x0623,   # 64 bit pointer to 64 bit unsigned
-
-
-#      64 bit int types
-
-    "T_INT8"          : 0x0076,   # 64 bit signed int
-    "T_PINT8"         : 0x0176,   # 16 bit pointer to 64 bit signed int
-    "T_PFINT8"        : 0x0276,   # 16:16 far pointer to 64 bit signed int
-    "T_PHINT8"        : 0x0376,   # 16:16 huge pointer to 64 bit signed int
-    "T_32PINT8"       : 0x0476,   # 32 bit pointer to 64 bit signed int
-    "T_32PFINT8"      : 0x0576,   # 16:32 pointer to 64 bit signed int
-    "T_64PINT8"       : 0x0676,   # 64 bit pointer to 64 bit signed int
-
-    "T_UINT8"         : 0x0077,   # 64 bit unsigned int
-    "T_PUINT8"        : 0x0177,   # 16 bit pointer to 64 bit unsigned int
-    "T_PFUINT8"       : 0x0277,   # 16:16 far pointer to 64 bit unsigned int
-    "T_PHUINT8"       : 0x0377,   # 16:16 huge pointer to 64 bit unsigned int
-    "T_32PUINT8"      : 0x0477,   # 32 bit pointer to 64 bit unsigned int
-    "T_32PFUINT8"     : 0x0577,   # 16:32 pointer to 64 bit unsigned int
-    "T_64PUINT8"      : 0x0677,   # 64 bit pointer to 64 bit unsigned int
-
-
-#      128 bit octet types
-
-    "T_OCT"           : 0x0014,   # 128 bit signed
-    "T_POCT"          : 0x0114,   # 16 bit pointer to 128 bit signed
-    "T_PFOCT"         : 0x0214,   # 16:16 far pointer to 128 bit signed
-    "T_PHOCT"         : 0x0314,   # 16:16 huge pointer to 128 bit signed
-    "T_32POCT"        : 0x0414,   # 32 bit pointer to 128 bit signed
-    "T_32PFOCT"       : 0x0514,   # 16:32 pointer to 128 bit signed
-    "T_64POCT"        : 0x0614,   # 64 bit pointer to 128 bit signed
-
-    "T_UOCT"          : 0x0024,   # 128 bit unsigned
-    "T_PUOCT"         : 0x0124,   # 16 bit pointer to 128 bit unsigned
-    "T_PFUOCT"        : 0x0224,   # 16:16 far pointer to 128 bit unsigned
-    "T_PHUOCT"        : 0x0324,   # 16:16 huge pointer to 128 bit unsigned
-    "T_32PUOCT"       : 0x0424,   # 32 bit pointer to 128 bit unsigned
-    "T_32PFUOCT"      : 0x0524,   # 16:32 pointer to 128 bit unsigned
-    "T_64PUOCT"       : 0x0624,   # 64 bit pointer to 128 bit unsigned
-
-
-#      128 bit int types
-
-    "T_INT16"         : 0x0078,   # 128 bit signed int
-    "T_PINT16"        : 0x0178,   # 16 bit pointer to 128 bit signed int
-    "T_PFINT16"       : 0x0278,   # 16:16 far pointer to 128 bit signed int
-    "T_PHINT16"       : 0x0378,   # 16:16 huge pointer to 128 bit signed int
-    "T_32PINT16"      : 0x0478,   # 32 bit pointer to 128 bit signed int
-    "T_32PFINT16"     : 0x0578,   # 16:32 pointer to 128 bit signed int
-    "T_64PINT16"      : 0x0678,   # 64 bit pointer to 128 bit signed int
-
-    "T_UINT16"        : 0x0079,   # 128 bit unsigned int
-    "T_PUINT16"       : 0x0179,   # 16 bit pointer to 128 bit unsigned int
-    "T_PFUINT16"      : 0x0279,   # 16:16 far pointer to 128 bit unsigned int
-    "T_PHUINT16"      : 0x0379,   # 16:16 huge pointer to 128 bit unsigned int
-    "T_32PUINT16"     : 0x0479,   # 32 bit pointer to 128 bit unsigned int
-    "T_32PFUINT16"    : 0x0579,   # 16:32 pointer to 128 bit unsigned int
-    "T_64PUINT16"     : 0x0679,   # 64 bit pointer to 128 bit unsigned int
-
-
-#      16 bit real types
-
-    "T_REAL16"        : 0x0046,   # 16 bit real
-    "T_PREAL16"       : 0x0146,   # 16 bit pointer to 16 bit real
-    "T_PFREAL16"      : 0x0246,   # 16:16 far pointer to 16 bit real
-    "T_PHREAL16"      : 0x0346,   # 16:16 huge pointer to 16 bit real
-    "T_32PREAL16"     : 0x0446,   # 32 bit pointer to 16 bit real
-    "T_32PFREAL16"    : 0x0546,   # 16:32 pointer to 16 bit real
-    "T_64PREAL16"     : 0x0646,   # 64 bit pointer to 16 bit real
-
-
-#      32 bit real types
-
-    "T_REAL32"        : 0x0040,   # 32 bit real
-    "T_PREAL32"       : 0x0140,   # 16 bit pointer to 32 bit real
-    "T_PFREAL32"      : 0x0240,   # 16:16 far pointer to 32 bit real
-    "T_PHREAL32"      : 0x0340,   # 16:16 huge pointer to 32 bit real
-    "T_32PREAL32"     : 0x0440,   # 32 bit pointer to 32 bit real
-    "T_32PFREAL32"    : 0x0540,   # 16:32 pointer to 32 bit real
-    "T_64PREAL32"     : 0x0640,   # 64 bit pointer to 32 bit real
-
-
-#      32 bit partial-precision real types
-
-    "T_REAL32PP"      : 0x0045,   # 32 bit PP real
-    "T_PREAL32PP"     : 0x0145,   # 16 bit pointer to 32 bit PP real
-    "T_PFREAL32PP"    : 0x0245,   # 16:16 far pointer to 32 bit PP real
-    "T_PHREAL32PP"    : 0x0345,   # 16:16 huge pointer to 32 bit PP real
-    "T_32PREAL32PP"   : 0x0445,   # 32 bit pointer to 32 bit PP real
-    "T_32PFREAL32PP"  : 0x0545,   # 16:32 pointer to 32 bit PP real
-    "T_64PREAL32PP"   : 0x0645,   # 64 bit pointer to 32 bit PP real
-
-
-#      48 bit real types
-
-    "T_REAL48"        : 0x0044,   # 48 bit real
-    "T_PREAL48"       : 0x0144,   # 16 bit pointer to 48 bit real
-    "T_PFREAL48"      : 0x0244,   # 16:16 far pointer to 48 bit real
-    "T_PHREAL48"      : 0x0344,   # 16:16 huge pointer to 48 bit real
-    "T_32PREAL48"     : 0x0444,   # 32 bit pointer to 48 bit real
-    "T_32PFREAL48"    : 0x0544,   # 16:32 pointer to 48 bit real
-    "T_64PREAL48"     : 0x0644,   # 64 bit pointer to 48 bit real
-
-
-#      64 bit real types
-
-    "T_REAL64"        : 0x0041,   # 64 bit real
-    "T_PREAL64"       : 0x0141,   # 16 bit pointer to 64 bit real
-    "T_PFREAL64"      : 0x0241,   # 16:16 far pointer to 64 bit real
-    "T_PHREAL64"      : 0x0341,   # 16:16 huge pointer to 64 bit real
-    "T_32PREAL64"     : 0x0441,   # 32 bit pointer to 64 bit real
-    "T_32PFREAL64"    : 0x0541,   # 16:32 pointer to 64 bit real
-    "T_64PREAL64"     : 0x0641,   # 64 bit pointer to 64 bit real
-
-
-#      80 bit real types
-
-    "T_REAL80"        : 0x0042,   # 80 bit real
-    "T_PREAL80"       : 0x0142,   # 16 bit pointer to 80 bit real
-    "T_PFREAL80"      : 0x0242,   # 16:16 far pointer to 80 bit real
-    "T_PHREAL80"      : 0x0342,   # 16:16 huge pointer to 80 bit real
-    "T_32PREAL80"     : 0x0442,   # 32 bit pointer to 80 bit real
-    "T_32PFREAL80"    : 0x0542,   # 16:32 pointer to 80 bit real
-    "T_64PREAL80"     : 0x0642,   # 64 bit pointer to 80 bit real
-
-
-#      128 bit real types
-
-    "T_REAL128"       : 0x0043,   # 128 bit real
-    "T_PREAL128"      : 0x0143,   # 16 bit pointer to 128 bit real
-    "T_PFREAL128"     : 0x0243,   # 16:16 far pointer to 128 bit real
-    "T_PHREAL128"     : 0x0343,   # 16:16 huge pointer to 128 bit real
-    "T_32PREAL128"    : 0x0443,   # 32 bit pointer to 128 bit real
-    "T_32PFREAL128"   : 0x0543,   # 16:32 pointer to 128 bit real
-    "T_64PREAL128"    : 0x0643,   # 64 bit pointer to 128 bit real
-
-
-#      32 bit complex types
-
-    "T_CPLX32"        : 0x0050,   # 32 bit complex
-    "T_PCPLX32"       : 0x0150,   # 16 bit pointer to 32 bit complex
-    "T_PFCPLX32"      : 0x0250,   # 16:16 far pointer to 32 bit complex
-    "T_PHCPLX32"      : 0x0350,   # 16:16 huge pointer to 32 bit complex
-    "T_32PCPLX32"     : 0x0450,   # 32 bit pointer to 32 bit complex
-    "T_32PFCPLX32"    : 0x0550,   # 16:32 pointer to 32 bit complex
-    "T_64PCPLX32"     : 0x0650,   # 64 bit pointer to 32 bit complex
-
-
-#      64 bit complex types
-
-    "T_CPLX64"        : 0x0051,   # 64 bit complex
-    "T_PCPLX64"       : 0x0151,   # 16 bit pointer to 64 bit complex
-    "T_PFCPLX64"      : 0x0251,   # 16:16 far pointer to 64 bit complex
-    "T_PHCPLX64"      : 0x0351,   # 16:16 huge pointer to 64 bit complex
-    "T_32PCPLX64"     : 0x0451,   # 32 bit pointer to 64 bit complex
-    "T_32PFCPLX64"    : 0x0551,   # 16:32 pointer to 64 bit complex
-    "T_64PCPLX64"     : 0x0651,   # 64 bit pointer to 64 bit complex
-
-
-#      80 bit complex types
-
-    "T_CPLX80"        : 0x0052,   # 80 bit complex
-    "T_PCPLX80"       : 0x0152,   # 16 bit pointer to 80 bit complex
-    "T_PFCPLX80"      : 0x0252,   # 16:16 far pointer to 80 bit complex
-    "T_PHCPLX80"      : 0x0352,   # 16:16 huge pointer to 80 bit complex
-    "T_32PCPLX80"     : 0x0452,   # 32 bit pointer to 80 bit complex
-    "T_32PFCPLX80"    : 0x0552,   # 16:32 pointer to 80 bit complex
-    "T_64PCPLX80"     : 0x0652,   # 64 bit pointer to 80 bit complex
-
-
-#      128 bit complex types
-
-    "T_CPLX128"       : 0x0053,   # 128 bit complex
-    "T_PCPLX128"      : 0x0153,   # 16 bit pointer to 128 bit complex
-    "T_PFCPLX128"     : 0x0253,   # 16:16 far pointer to 128 bit complex
-    "T_PHCPLX128"     : 0x0353,   # 16:16 huge pointer to 128 bit real
-    "T_32PCPLX128"    : 0x0453,   # 32 bit pointer to 128 bit complex
-    "T_32PFCPLX128"   : 0x0553,   # 16:32 pointer to 128 bit complex
-    "T_64PCPLX128"    : 0x0653,   # 64 bit pointer to 128 bit complex
-
-
-#      boolean types
-
-    "T_BOOL08"        : 0x0030,   # 8 bit boolean
-    "T_PBOOL08"       : 0x0130,   # 16 bit pointer to  8 bit boolean
-    "T_PFBOOL08"      : 0x0230,   # 16:16 far pointer to  8 bit boolean
-    "T_PHBOOL08"      : 0x0330,   # 16:16 huge pointer to  8 bit boolean
-    "T_32PBOOL08"     : 0x0430,   # 32 bit pointer to 8 bit boolean
-    "T_32PFBOOL08"    : 0x0530,   # 16:32 pointer to 8 bit boolean
-    "T_64PBOOL08"     : 0x0630,   # 64 bit pointer to 8 bit boolean
-
-    "T_BOOL16"        : 0x0031,   # 16 bit boolean
-    "T_PBOOL16"       : 0x0131,   # 16 bit pointer to 16 bit boolean
-    "T_PFBOOL16"      : 0x0231,   # 16:16 far pointer to 16 bit boolean
-    "T_PHBOOL16"      : 0x0331,   # 16:16 huge pointer to 16 bit boolean
-    "T_32PBOOL16"     : 0x0431,   # 32 bit pointer to 18 bit boolean
-    "T_32PFBOOL16"    : 0x0531,   # 16:32 pointer to 16 bit boolean
-    "T_64PBOOL16"     : 0x0631,   # 64 bit pointer to 18 bit boolean
-
-    "T_BOOL32"        : 0x0032,   # 32 bit boolean
-    "T_PBOOL32"       : 0x0132,   # 16 bit pointer to 32 bit boolean
-    "T_PFBOOL32"      : 0x0232,   # 16:16 far pointer to 32 bit boolean
-    "T_PHBOOL32"      : 0x0332,   # 16:16 huge pointer to 32 bit boolean
-    "T_32PBOOL32"     : 0x0432,   # 32 bit pointer to 32 bit boolean
-    "T_32PFBOOL32"    : 0x0532,   # 16:32 pointer to 32 bit boolean
-    "T_64PBOOL32"     : 0x0632,   # 64 bit pointer to 32 bit boolean
-
-    "T_BOOL64"        : 0x0033,   # 64 bit boolean
-    "T_PBOOL64"       : 0x0133,   # 16 bit pointer to 64 bit boolean
-    "T_PFBOOL64"      : 0x0233,   # 16:16 far pointer to 64 bit boolean
-    "T_PHBOOL64"      : 0x0333,   # 16:16 huge pointer to 64 bit boolean
-    "T_32PBOOL64"     : 0x0433,   # 32 bit pointer to 64 bit boolean
-    "T_32PFBOOL64"    : 0x0533,   # 16:32 pointer to 64 bit boolean
-    "T_64PBOOL64"     : 0x0633,   # 64 bit pointer to 64 bit boolean
-
-
-#      ???
-
-    "T_NCVPTR"        : 0x01f0,   # CV Internal type for created near pointers
-    "T_FCVPTR"        : 0x02f0,   # CV Internal type for created far pointers
-    "T_HCVPTR"        : 0x03f0,   # CV Internal type for created huge pointers
-    "T_32NCVPTR"      : 0x04f0,   # CV Internal type for created near 32-bit pointers
-    "T_32FCVPTR"      : 0x05f0,   # CV Internal type for created far 32-bit pointers
-    "T_64NCVPTR" : 0x06f0, # CV Internal type for created near 64-bit pointers
+    "T_NOTYPE": 0x0000,  # uncharacterized type (no type)
+    "T_ABS": 0x0001,  # absolute symbol
+    "T_SEGMENT": 0x0002,  # segment type
+    "T_VOID": 0x0003,  # void
+    "T_HRESULT": 0x0008,  # OLE/COM HRESULT
+    "T_32PHRESULT": 0x0408,  # OLE/COM HRESULT __ptr32 *
+    "T_64PHRESULT": 0x0608,  # OLE/COM HRESULT __ptr64 *
+    "T_PVOID": 0x0103,  # near pointer to void
+    "T_PFVOID": 0x0203,  # far pointer to void
+    "T_PHVOID": 0x0303,  # huge pointer to void
+    "T_32PVOID": 0x0403,  # 32 bit pointer to void
+    "T_32PFVOID": 0x0503,  # 16:32 pointer to void
+    "T_64PVOID": 0x0603,  # 64 bit pointer to void
+    "T_CURRENCY": 0x0004,  # BASIC 8 byte currency value
+    "T_NBASICSTR": 0x0005,  # Near BASIC string
+    "T_FBASICSTR": 0x0006,  # Far BASIC string
+    "T_NOTTRANS": 0x0007,  # type not translated by cvpack
+    "T_BIT": 0x0060,  # bit
+    "T_PASCHAR": 0x0061,  # Pascal CHAR
+    "T_BOOL32FF": 0x0062,  # 32-bit BOOL where true is 0xffffffff
+
+    #      Character types
+    "T_CHAR": 0x0010,  # 8 bit signed
+    "T_PCHAR": 0x0110,  # 16 bit pointer to 8 bit signed
+    "T_PFCHAR": 0x0210,  # 16:16 far pointer to 8 bit signed
+    "T_PHCHAR": 0x0310,  # 16:16 huge pointer to 8 bit signed
+    "T_32PCHAR": 0x0410,  # 32 bit pointer to 8 bit signed
+    "T_32PFCHAR": 0x0510,  # 16:32 pointer to 8 bit signed
+    "T_64PCHAR": 0x0610,  # 64 bit pointer to 8 bit signed
+    "T_UCHAR": 0x0020,  # 8 bit unsigned
+    "T_PUCHAR": 0x0120,  # 16 bit pointer to 8 bit unsigned
+    "T_PFUCHAR": 0x0220,  # 16:16 far pointer to 8 bit unsigned
+    "T_PHUCHAR": 0x0320,  # 16:16 huge pointer to 8 bit unsigned
+    "T_32PUCHAR": 0x0420,  # 32 bit pointer to 8 bit unsigned
+    "T_32PFUCHAR": 0x0520,  # 16:32 pointer to 8 bit unsigned
+    "T_64PUCHAR": 0x0620,  # 64 bit pointer to 8 bit unsigned
+
+    #      really a character types
+    "T_RCHAR": 0x0070,  # really a char
+    "T_PRCHAR": 0x0170,  # 16 bit pointer to a real char
+    "T_PFRCHAR": 0x0270,  # 16:16 far pointer to a real char
+    "T_PHRCHAR": 0x0370,  # 16:16 huge pointer to a real char
+    "T_32PRCHAR": 0x0470,  # 32 bit pointer to a real char
+    "T_32PFRCHAR": 0x0570,  # 16:32 pointer to a real char
+    "T_64PRCHAR": 0x0670,  # 64 bit pointer to a real char
+
+    #      really a wide character types
+    "T_WCHAR": 0x0071,  # wide char
+    "T_PWCHAR": 0x0171,  # 16 bit pointer to a wide char
+    "T_PFWCHAR": 0x0271,  # 16:16 far pointer to a wide char
+    "T_PHWCHAR": 0x0371,  # 16:16 huge pointer to a wide char
+    "T_32PWCHAR": 0x0471,  # 32 bit pointer to a wide char
+    "T_32PFWCHAR": 0x0571,  # 16:32 pointer to a wide char
+    "T_64PWCHAR": 0x0671,  # 64 bit pointer to a wide char
+
+    #      really a 16-bit unicode char
+    "T_CHAR16": 0x007a,  # 16-bit unicode char
+    "T_PCHAR16": 0x017a,  # 16 bit pointer to a 16-bit unicode char
+    "T_PFCHAR16": 0x027a,  # 16:16 far pointer to a 16-bit unicode char
+    "T_PHCHAR16": 0x037a,  # 16:16 huge pointer to a 16-bit unicode char
+    "T_32PCHAR16": 0x047a,  # 32 bit pointer to a 16-bit unicode char
+    "T_32PFCHAR16": 0x057a,  # 16:32 pointer to a 16-bit unicode char
+    "T_64PCHAR16": 0x067a,  # 64 bit pointer to a 16-bit unicode char
+
+    #      really a 32-bit unicode char
+    "T_CHAR32": 0x007b,  # 32-bit unicode char
+    "T_PCHAR32": 0x017b,  # 16 bit pointer to a 32-bit unicode char
+    "T_PFCHAR32": 0x027b,  # 16:16 far pointer to a 32-bit unicode char
+    "T_PHCHAR32": 0x037b,  # 16:16 huge pointer to a 32-bit unicode char
+    "T_32PCHAR32": 0x047b,  # 32 bit pointer to a 32-bit unicode char
+    "T_32PFCHAR32": 0x057b,  # 16:32 pointer to a 32-bit unicode char
+    "T_64PCHAR32": 0x067b,  # 64 bit pointer to a 32-bit unicode char
+
+    #      8 bit int types
+    "T_INT1": 0x0068,  # 8 bit signed int
+    "T_PINT1": 0x0168,  # 16 bit pointer to 8 bit signed int
+    "T_PFINT1": 0x0268,  # 16:16 far pointer to 8 bit signed int
+    "T_PHINT1": 0x0368,  # 16:16 huge pointer to 8 bit signed int
+    "T_32PINT1": 0x0468,  # 32 bit pointer to 8 bit signed int
+    "T_32PFINT1": 0x0568,  # 16:32 pointer to 8 bit signed int
+    "T_64PINT1": 0x0668,  # 64 bit pointer to 8 bit signed int
+    "T_UINT1": 0x0069,  # 8 bit unsigned int
+    "T_PUINT1": 0x0169,  # 16 bit pointer to 8 bit unsigned int
+    "T_PFUINT1": 0x0269,  # 16:16 far pointer to 8 bit unsigned int
+    "T_PHUINT1": 0x0369,  # 16:16 huge pointer to 8 bit unsigned int
+    "T_32PUINT1": 0x0469,  # 32 bit pointer to 8 bit unsigned int
+    "T_32PFUINT1": 0x0569,  # 16:32 pointer to 8 bit unsigned int
+    "T_64PUINT1": 0x0669,  # 64 bit pointer to 8 bit unsigned int
+
+    #      16 bit short types
+    "T_SHORT": 0x0011,  # 16 bit signed
+    "T_PSHORT": 0x0111,  # 16 bit pointer to 16 bit signed
+    "T_PFSHORT": 0x0211,  # 16:16 far pointer to 16 bit signed
+    "T_PHSHORT": 0x0311,  # 16:16 huge pointer to 16 bit signed
+    "T_32PSHORT": 0x0411,  # 32 bit pointer to 16 bit signed
+    "T_32PFSHORT": 0x0511,  # 16:32 pointer to 16 bit signed
+    "T_64PSHORT": 0x0611,  # 64 bit pointer to 16 bit signed
+    "T_USHORT": 0x0021,  # 16 bit unsigned
+    "T_PUSHORT": 0x0121,  # 16 bit pointer to 16 bit unsigned
+    "T_PFUSHORT": 0x0221,  # 16:16 far pointer to 16 bit unsigned
+    "T_PHUSHORT": 0x0321,  # 16:16 huge pointer to 16 bit unsigned
+    "T_32PUSHORT": 0x0421,  # 32 bit pointer to 16 bit unsigned
+    "T_32PFUSHORT": 0x0521,  # 16:32 pointer to 16 bit unsigned
+    "T_64PUSHORT": 0x0621,  # 64 bit pointer to 16 bit unsigned
+
+    #      16 bit int types
+    "T_INT2": 0x0072,  # 16 bit signed int
+    "T_PINT2": 0x0172,  # 16 bit pointer to 16 bit signed int
+    "T_PFINT2": 0x0272,  # 16:16 far pointer to 16 bit signed int
+    "T_PHINT2": 0x0372,  # 16:16 huge pointer to 16 bit signed int
+    "T_32PINT2": 0x0472,  # 32 bit pointer to 16 bit signed int
+    "T_32PFINT2": 0x0572,  # 16:32 pointer to 16 bit signed int
+    "T_64PINT2": 0x0672,  # 64 bit pointer to 16 bit signed int
+    "T_UINT2": 0x0073,  # 16 bit unsigned int
+    "T_PUINT2": 0x0173,  # 16 bit pointer to 16 bit unsigned int
+    "T_PFUINT2": 0x0273,  # 16:16 far pointer to 16 bit unsigned int
+    "T_PHUINT2": 0x0373,  # 16:16 huge pointer to 16 bit unsigned int
+    "T_32PUINT2": 0x0473,  # 32 bit pointer to 16 bit unsigned int
+    "T_32PFUINT2": 0x0573,  # 16:32 pointer to 16 bit unsigned int
+    "T_64PUINT2": 0x0673,  # 64 bit pointer to 16 bit unsigned int
+
+    #      32 bit long types
+    "T_LONG": 0x0012,  # 32 bit signed
+    "T_ULONG": 0x0022,  # 32 bit unsigned
+    "T_PLONG": 0x0112,  # 16 bit pointer to 32 bit signed
+    "T_PULONG": 0x0122,  # 16 bit pointer to 32 bit unsigned
+    "T_PFLONG": 0x0212,  # 16:16 far pointer to 32 bit signed
+    "T_PFULONG": 0x0222,  # 16:16 far pointer to 32 bit unsigned
+    "T_PHLONG": 0x0312,  # 16:16 huge pointer to 32 bit signed
+    "T_PHULONG": 0x0322,  # 16:16 huge pointer to 32 bit unsigned
+    "T_32PLONG": 0x0412,  # 32 bit pointer to 32 bit signed
+    "T_32PULONG": 0x0422,  # 32 bit pointer to 32 bit unsigned
+    "T_32PFLONG": 0x0512,  # 16:32 pointer to 32 bit signed
+    "T_32PFULONG": 0x0522,  # 16:32 pointer to 32 bit unsigned
+    "T_64PLONG": 0x0612,  # 64 bit pointer to 32 bit signed
+    "T_64PULONG": 0x0622,  # 64 bit pointer to 32 bit unsigned
+
+    #      32 bit int types
+    "T_INT4": 0x0074,  # 32 bit signed int
+    "T_PINT4": 0x0174,  # 16 bit pointer to 32 bit signed int
+    "T_PFINT4": 0x0274,  # 16:16 far pointer to 32 bit signed int
+    "T_PHINT4": 0x0374,  # 16:16 huge pointer to 32 bit signed int
+    "T_32PINT4": 0x0474,  # 32 bit pointer to 32 bit signed int
+    "T_32PFINT4": 0x0574,  # 16:32 pointer to 32 bit signed int
+    "T_64PINT4": 0x0674,  # 64 bit pointer to 32 bit signed int
+    "T_UINT4": 0x0075,  # 32 bit unsigned int
+    "T_PUINT4": 0x0175,  # 16 bit pointer to 32 bit unsigned int
+    "T_PFUINT4": 0x0275,  # 16:16 far pointer to 32 bit unsigned int
+    "T_PHUINT4": 0x0375,  # 16:16 huge pointer to 32 bit unsigned int
+    "T_32PUINT4": 0x0475,  # 32 bit pointer to 32 bit unsigned int
+    "T_32PFUINT4": 0x0575,  # 16:32 pointer to 32 bit unsigned int
+    "T_64PUINT4": 0x0675,  # 64 bit pointer to 32 bit unsigned int
+
+    #      64 bit quad types
+    "T_QUAD": 0x0013,  # 64 bit signed
+    "T_PQUAD": 0x0113,  # 16 bit pointer to 64 bit signed
+    "T_PFQUAD": 0x0213,  # 16:16 far pointer to 64 bit signed
+    "T_PHQUAD": 0x0313,  # 16:16 huge pointer to 64 bit signed
+    "T_32PQUAD": 0x0413,  # 32 bit pointer to 64 bit signed
+    "T_32PFQUAD": 0x0513,  # 16:32 pointer to 64 bit signed
+    "T_64PQUAD": 0x0613,  # 64 bit pointer to 64 bit signed
+    "T_UQUAD": 0x0023,  # 64 bit unsigned
+    "T_PUQUAD": 0x0123,  # 16 bit pointer to 64 bit unsigned
+    "T_PFUQUAD": 0x0223,  # 16:16 far pointer to 64 bit unsigned
+    "T_PHUQUAD": 0x0323,  # 16:16 huge pointer to 64 bit unsigned
+    "T_32PUQUAD": 0x0423,  # 32 bit pointer to 64 bit unsigned
+    "T_32PFUQUAD": 0x0523,  # 16:32 pointer to 64 bit unsigned
+    "T_64PUQUAD": 0x0623,  # 64 bit pointer to 64 bit unsigned
+
+    #      64 bit int types
+    "T_INT8": 0x0076,  # 64 bit signed int
+    "T_PINT8": 0x0176,  # 16 bit pointer to 64 bit signed int
+    "T_PFINT8": 0x0276,  # 16:16 far pointer to 64 bit signed int
+    "T_PHINT8": 0x0376,  # 16:16 huge pointer to 64 bit signed int
+    "T_32PINT8": 0x0476,  # 32 bit pointer to 64 bit signed int
+    "T_32PFINT8": 0x0576,  # 16:32 pointer to 64 bit signed int
+    "T_64PINT8": 0x0676,  # 64 bit pointer to 64 bit signed int
+    "T_UINT8": 0x0077,  # 64 bit unsigned int
+    "T_PUINT8": 0x0177,  # 16 bit pointer to 64 bit unsigned int
+    "T_PFUINT8": 0x0277,  # 16:16 far pointer to 64 bit unsigned int
+    "T_PHUINT8": 0x0377,  # 16:16 huge pointer to 64 bit unsigned int
+    "T_32PUINT8": 0x0477,  # 32 bit pointer to 64 bit unsigned int
+    "T_32PFUINT8": 0x0577,  # 16:32 pointer to 64 bit unsigned int
+    "T_64PUINT8": 0x0677,  # 64 bit pointer to 64 bit unsigned int
+
+    #      128 bit octet types
+    "T_OCT": 0x0014,  # 128 bit signed
+    "T_POCT": 0x0114,  # 16 bit pointer to 128 bit signed
+    "T_PFOCT": 0x0214,  # 16:16 far pointer to 128 bit signed
+    "T_PHOCT": 0x0314,  # 16:16 huge pointer to 128 bit signed
+    "T_32POCT": 0x0414,  # 32 bit pointer to 128 bit signed
+    "T_32PFOCT": 0x0514,  # 16:32 pointer to 128 bit signed
+    "T_64POCT": 0x0614,  # 64 bit pointer to 128 bit signed
+    "T_UOCT": 0x0024,  # 128 bit unsigned
+    "T_PUOCT": 0x0124,  # 16 bit pointer to 128 bit unsigned
+    "T_PFUOCT": 0x0224,  # 16:16 far pointer to 128 bit unsigned
+    "T_PHUOCT": 0x0324,  # 16:16 huge pointer to 128 bit unsigned
+    "T_32PUOCT": 0x0424,  # 32 bit pointer to 128 bit unsigned
+    "T_32PFUOCT": 0x0524,  # 16:32 pointer to 128 bit unsigned
+    "T_64PUOCT": 0x0624,  # 64 bit pointer to 128 bit unsigned
+
+    #      128 bit int types
+    "T_INT16": 0x0078,  # 128 bit signed int
+    "T_PINT16": 0x0178,  # 16 bit pointer to 128 bit signed int
+    "T_PFINT16": 0x0278,  # 16:16 far pointer to 128 bit signed int
+    "T_PHINT16": 0x0378,  # 16:16 huge pointer to 128 bit signed int
+    "T_32PINT16": 0x0478,  # 32 bit pointer to 128 bit signed int
+    "T_32PFINT16": 0x0578,  # 16:32 pointer to 128 bit signed int
+    "T_64PINT16": 0x0678,  # 64 bit pointer to 128 bit signed int
+    "T_UINT16": 0x0079,  # 128 bit unsigned int
+    "T_PUINT16": 0x0179,  # 16 bit pointer to 128 bit unsigned int
+    "T_PFUINT16": 0x0279,  # 16:16 far pointer to 128 bit unsigned int
+    "T_PHUINT16": 0x0379,  # 16:16 huge pointer to 128 bit unsigned int
+    "T_32PUINT16": 0x0479,  # 32 bit pointer to 128 bit unsigned int
+    "T_32PFUINT16": 0x0579,  # 16:32 pointer to 128 bit unsigned int
+    "T_64PUINT16": 0x0679,  # 64 bit pointer to 128 bit unsigned int
+
+    #      16 bit real types
+    "T_REAL16": 0x0046,  # 16 bit real
+    "T_PREAL16": 0x0146,  # 16 bit pointer to 16 bit real
+    "T_PFREAL16": 0x0246,  # 16:16 far pointer to 16 bit real
+    "T_PHREAL16": 0x0346,  # 16:16 huge pointer to 16 bit real
+    "T_32PREAL16": 0x0446,  # 32 bit pointer to 16 bit real
+    "T_32PFREAL16": 0x0546,  # 16:32 pointer to 16 bit real
+    "T_64PREAL16": 0x0646,  # 64 bit pointer to 16 bit real
+
+    #      32 bit real types
+    "T_REAL32": 0x0040,  # 32 bit real
+    "T_PREAL32": 0x0140,  # 16 bit pointer to 32 bit real
+    "T_PFREAL32": 0x0240,  # 16:16 far pointer to 32 bit real
+    "T_PHREAL32": 0x0340,  # 16:16 huge pointer to 32 bit real
+    "T_32PREAL32": 0x0440,  # 32 bit pointer to 32 bit real
+    "T_32PFREAL32": 0x0540,  # 16:32 pointer to 32 bit real
+    "T_64PREAL32": 0x0640,  # 64 bit pointer to 32 bit real
+
+    #      32 bit partial-precision real types
+    "T_REAL32PP": 0x0045,  # 32 bit PP real
+    "T_PREAL32PP": 0x0145,  # 16 bit pointer to 32 bit PP real
+    "T_PFREAL32PP": 0x0245,  # 16:16 far pointer to 32 bit PP real
+    "T_PHREAL32PP": 0x0345,  # 16:16 huge pointer to 32 bit PP real
+    "T_32PREAL32PP": 0x0445,  # 32 bit pointer to 32 bit PP real
+    "T_32PFREAL32PP": 0x0545,  # 16:32 pointer to 32 bit PP real
+    "T_64PREAL32PP": 0x0645,  # 64 bit pointer to 32 bit PP real
+
+    #      48 bit real types
+    "T_REAL48": 0x0044,  # 48 bit real
+    "T_PREAL48": 0x0144,  # 16 bit pointer to 48 bit real
+    "T_PFREAL48": 0x0244,  # 16:16 far pointer to 48 bit real
+    "T_PHREAL48": 0x0344,  # 16:16 huge pointer to 48 bit real
+    "T_32PREAL48": 0x0444,  # 32 bit pointer to 48 bit real
+    "T_32PFREAL48": 0x0544,  # 16:32 pointer to 48 bit real
+    "T_64PREAL48": 0x0644,  # 64 bit pointer to 48 bit real
+
+    #      64 bit real types
+    "T_REAL64": 0x0041,  # 64 bit real
+    "T_PREAL64": 0x0141,  # 16 bit pointer to 64 bit real
+    "T_PFREAL64": 0x0241,  # 16:16 far pointer to 64 bit real
+    "T_PHREAL64": 0x0341,  # 16:16 huge pointer to 64 bit real
+    "T_32PREAL64": 0x0441,  # 32 bit pointer to 64 bit real
+    "T_32PFREAL64": 0x0541,  # 16:32 pointer to 64 bit real
+    "T_64PREAL64": 0x0641,  # 64 bit pointer to 64 bit real
+
+    #      80 bit real types
+    "T_REAL80": 0x0042,  # 80 bit real
+    "T_PREAL80": 0x0142,  # 16 bit pointer to 80 bit real
+    "T_PFREAL80": 0x0242,  # 16:16 far pointer to 80 bit real
+    "T_PHREAL80": 0x0342,  # 16:16 huge pointer to 80 bit real
+    "T_32PREAL80": 0x0442,  # 32 bit pointer to 80 bit real
+    "T_32PFREAL80": 0x0542,  # 16:32 pointer to 80 bit real
+    "T_64PREAL80": 0x0642,  # 64 bit pointer to 80 bit real
+
+    #      128 bit real types
+    "T_REAL128": 0x0043,  # 128 bit real
+    "T_PREAL128": 0x0143,  # 16 bit pointer to 128 bit real
+    "T_PFREAL128": 0x0243,  # 16:16 far pointer to 128 bit real
+    "T_PHREAL128": 0x0343,  # 16:16 huge pointer to 128 bit real
+    "T_32PREAL128": 0x0443,  # 32 bit pointer to 128 bit real
+    "T_32PFREAL128": 0x0543,  # 16:32 pointer to 128 bit real
+    "T_64PREAL128": 0x0643,  # 64 bit pointer to 128 bit real
+
+    #      32 bit complex types
+    "T_CPLX32": 0x0050,  # 32 bit complex
+    "T_PCPLX32": 0x0150,  # 16 bit pointer to 32 bit complex
+    "T_PFCPLX32": 0x0250,  # 16:16 far pointer to 32 bit complex
+    "T_PHCPLX32": 0x0350,  # 16:16 huge pointer to 32 bit complex
+    "T_32PCPLX32": 0x0450,  # 32 bit pointer to 32 bit complex
+    "T_32PFCPLX32": 0x0550,  # 16:32 pointer to 32 bit complex
+    "T_64PCPLX32": 0x0650,  # 64 bit pointer to 32 bit complex
+
+    #      64 bit complex types
+    "T_CPLX64": 0x0051,  # 64 bit complex
+    "T_PCPLX64": 0x0151,  # 16 bit pointer to 64 bit complex
+    "T_PFCPLX64": 0x0251,  # 16:16 far pointer to 64 bit complex
+    "T_PHCPLX64": 0x0351,  # 16:16 huge pointer to 64 bit complex
+    "T_32PCPLX64": 0x0451,  # 32 bit pointer to 64 bit complex
+    "T_32PFCPLX64": 0x0551,  # 16:32 pointer to 64 bit complex
+    "T_64PCPLX64": 0x0651,  # 64 bit pointer to 64 bit complex
+
+    #      80 bit complex types
+    "T_CPLX80": 0x0052,  # 80 bit complex
+    "T_PCPLX80": 0x0152,  # 16 bit pointer to 80 bit complex
+    "T_PFCPLX80": 0x0252,  # 16:16 far pointer to 80 bit complex
+    "T_PHCPLX80": 0x0352,  # 16:16 huge pointer to 80 bit complex
+    "T_32PCPLX80": 0x0452,  # 32 bit pointer to 80 bit complex
+    "T_32PFCPLX80": 0x0552,  # 16:32 pointer to 80 bit complex
+    "T_64PCPLX80": 0x0652,  # 64 bit pointer to 80 bit complex
+
+    #      128 bit complex types
+    "T_CPLX128": 0x0053,  # 128 bit complex
+    "T_PCPLX128": 0x0153,  # 16 bit pointer to 128 bit complex
+    "T_PFCPLX128": 0x0253,  # 16:16 far pointer to 128 bit complex
+    "T_PHCPLX128": 0x0353,  # 16:16 huge pointer to 128 bit real
+    "T_32PCPLX128": 0x0453,  # 32 bit pointer to 128 bit complex
+    "T_32PFCPLX128": 0x0553,  # 16:32 pointer to 128 bit complex
+    "T_64PCPLX128": 0x0653,  # 64 bit pointer to 128 bit complex
+
+    #      boolean types
+    "T_BOOL08": 0x0030,  # 8 bit boolean
+    "T_PBOOL08": 0x0130,  # 16 bit pointer to  8 bit boolean
+    "T_PFBOOL08": 0x0230,  # 16:16 far pointer to  8 bit boolean
+    "T_PHBOOL08": 0x0330,  # 16:16 huge pointer to  8 bit boolean
+    "T_32PBOOL08": 0x0430,  # 32 bit pointer to 8 bit boolean
+    "T_32PFBOOL08": 0x0530,  # 16:32 pointer to 8 bit boolean
+    "T_64PBOOL08": 0x0630,  # 64 bit pointer to 8 bit boolean
+    "T_BOOL16": 0x0031,  # 16 bit boolean
+    "T_PBOOL16": 0x0131,  # 16 bit pointer to 16 bit boolean
+    "T_PFBOOL16": 0x0231,  # 16:16 far pointer to 16 bit boolean
+    "T_PHBOOL16": 0x0331,  # 16:16 huge pointer to 16 bit boolean
+    "T_32PBOOL16": 0x0431,  # 32 bit pointer to 18 bit boolean
+    "T_32PFBOOL16": 0x0531,  # 16:32 pointer to 16 bit boolean
+    "T_64PBOOL16": 0x0631,  # 64 bit pointer to 18 bit boolean
+    "T_BOOL32": 0x0032,  # 32 bit boolean
+    "T_PBOOL32": 0x0132,  # 16 bit pointer to 32 bit boolean
+    "T_PFBOOL32": 0x0232,  # 16:16 far pointer to 32 bit boolean
+    "T_PHBOOL32": 0x0332,  # 16:16 huge pointer to 32 bit boolean
+    "T_32PBOOL32": 0x0432,  # 32 bit pointer to 32 bit boolean
+    "T_32PFBOOL32": 0x0532,  # 16:32 pointer to 32 bit boolean
+    "T_64PBOOL32": 0x0632,  # 64 bit pointer to 32 bit boolean
+    "T_BOOL64": 0x0033,  # 64 bit boolean
+    "T_PBOOL64": 0x0133,  # 16 bit pointer to 64 bit boolean
+    "T_PFBOOL64": 0x0233,  # 16:16 far pointer to 64 bit boolean
+    "T_PHBOOL64": 0x0333,  # 16:16 huge pointer to 64 bit boolean
+    "T_32PBOOL64": 0x0433,  # 32 bit pointer to 64 bit boolean
+    "T_32PFBOOL64": 0x0533,  # 16:32 pointer to 64 bit boolean
+    "T_64PBOOL64": 0x0633,  # 64 bit pointer to 64 bit boolean
+
+    #      ???
+    "T_NCVPTR": 0x01f0,  # CV Internal type for created near pointers
+    "T_FCVPTR": 0x02f0,  # CV Internal type for created far pointers
+    "T_HCVPTR": 0x03f0,  # CV Internal type for created huge pointers
+    "T_32NCVPTR": 0x04f0,  # CV Internal type for created near 32-bit pointers
+    "T_32FCVPTR": 0x05f0,  # CV Internal type for created far 32-bit pointers
+    "T_64NCVPTR": 0x06f0,  # CV Internal type for created near 64-bit pointers
 }
 
 base_type = Enum(ULInt16("base_type"), **base_types)
 
 # Fewer than 255 values so we're ok here
 # Exported from https:#github.com/Microsoft/microsoft-pdb/cvinfo.h#L772
-leaf_type = Enum(ULInt16("leaf_type"),
+leaf_type = Enum(
+    ULInt16("leaf_type"),
     # leaf indices starting records but referenced from symbol records
-
-    LF_MODIFIER_16t     = 0x0001,
-    LF_POINTER_16t      = 0x0002,
-    LF_ARRAY_16t        = 0x0003,
-    LF_CLASS_16t        = 0x0004,
-    LF_STRUCTURE_16t    = 0x0005,
-    LF_UNION_16t        = 0x0006,
-    LF_ENUM_16t         = 0x0007,
-    LF_PROCEDURE_16t    = 0x0008,
-    LF_MFUNCTION_16t    = 0x0009,
-    LF_VTSHAPE          = 0x000a,
-    LF_COBOL0_16t       = 0x000b,
-    LF_COBOL1           = 0x000c,
-    LF_BARRAY_16t       = 0x000d,
-    LF_LABEL            = 0x000e,
-    LF_NULL             = 0x000f,
-    LF_NOTTRAN          = 0x0010,
-    LF_DIMARRAY_16t     = 0x0011,
-    LF_VFTPATH_16t      = 0x0012,
-    LF_PRECOMP_16t      = 0x0013,       # not referenced from symbol
-    LF_ENDPRECOMP       = 0x0014,       # not referenced from symbol
-    LF_OEM_16t          = 0x0015,       # oem definable type string
-    LF_TYPESERVER_ST    = 0x0016,       # not referenced from symbol
-
-    # leaf indices starting records but referenced only from type records
-
-    LF_SKIP_16t         = 0x0200,
-    LF_ARGLIST_16t      = 0x0201,
-    LF_DEFARG_16t       = 0x0202,
-    LF_LIST             = 0x0203,
-    LF_FIELDLIST_16t    = 0x0204,
-    LF_DERIVED_16t      = 0x0205,
-    LF_BITFIELD_16t     = 0x0206,
-    LF_METHODLIST_16t   = 0x0207,
-    LF_DIMCONU_16t      = 0x0208,
-    LF_DIMCONLU_16t     = 0x0209,
-    LF_DIMVARU_16t      = 0x020a,
-    LF_DIMVARLU_16t     = 0x020b,
-    LF_REFSYM           = 0x020c,
-
-    LF_BCLASS_16t       = 0x0400,
-    LF_VBCLASS_16t      = 0x0401,
-    LF_IVBCLASS_16t     = 0x0402,
-    LF_ENUMERATE_ST     = 0x0403,
-    LF_FRIENDFCN_16t    = 0x0404,
-    LF_INDEX_16t        = 0x0405,
-    LF_MEMBER_16t       = 0x0406,
-    LF_STMEMBER_16t     = 0x0407,
-    LF_METHOD_16t       = 0x0408,
-    LF_NESTTYPE_16t     = 0x0409,
-    LF_VFUNCTAB_16t     = 0x040a,
-    LF_FRIENDCLS_16t    = 0x040b,
-    LF_ONEMETHOD_16t    = 0x040c,
-    LF_VFUNCOFF_16t     = 0x040d,
-
-# 32-bit type index versions of leaves, all have the 0x1000 bit set
-#
-    LF_TI16_MAX         = 0x1000,
-
-    LF_MODIFIER         = 0x1001,
-    LF_POINTER          = 0x1002,
-    LF_ARRAY_ST         = 0x1003,
-    LF_CLASS_ST         = 0x1004,
-    LF_STRUCTURE_ST     = 0x1005,
-    LF_UNION_ST         = 0x1006,
-    LF_ENUM_ST          = 0x1007,
-    LF_PROCEDURE        = 0x1008,
-    LF_MFUNCTION        = 0x1009,
-    LF_COBOL0           = 0x100a,
-    LF_BARRAY           = 0x100b,
-    LF_DIMARRAY_ST      = 0x100c,
-    LF_VFTPATH          = 0x100d,
-    LF_PRECOMP_ST       = 0x100e,       # not referenced from symbol
-    LF_OEM              = 0x100f,       # oem definable type string
-    LF_ALIAS_ST         = 0x1010,       # alias (typedef) type
-    LF_OEM2             = 0x1011,       # oem definable type string
+    LF_MODIFIER_16t = 0x0001,
+    LF_POINTER_16t = 0x0002,
+    LF_ARRAY_16t = 0x0003,
+    LF_CLASS_16t = 0x0004,
+    LF_STRUCTURE_16t = 0x0005,
+    LF_UNION_16t = 0x0006,
+    LF_ENUM_16t = 0x0007,
+    LF_PROCEDURE_16t = 0x0008,
+    LF_MFUNCTION_16t = 0x0009,
+    LF_VTSHAPE = 0x000a,
+    LF_COBOL0_16t = 0x000b,
+    LF_COBOL1 = 0x000c,
+    LF_BARRAY_16t = 0x000d,
+    LF_LABEL = 0x000e,
+    LF_NULL = 0x000f,
+    LF_NOTTRAN = 0x0010,
+    LF_DIMARRAY_16t = 0x0011,
+    LF_VFTPATH_16t = 0x0012,
+    LF_PRECOMP_16t = 0x0013,  # not referenced from symbol
+    LF_ENDPRECOMP = 0x0014,  # not referenced from symbol
+    LF_OEM_16t = 0x0015,  # oem definable type string
+    LF_TYPESERVER_ST = 0x0016,  # not referenced from symbol
 
     # leaf indices starting records but referenced only from type records
+    LF_SKIP_16t = 0x0200,
+    LF_ARGLIST_16t = 0x0201,
+    LF_DEFARG_16t = 0x0202,
+    LF_LIST = 0x0203,
+    LF_FIELDLIST_16t = 0x0204,
+    LF_DERIVED_16t = 0x0205,
+    LF_BITFIELD_16t = 0x0206,
+    LF_METHODLIST_16t = 0x0207,
+    LF_DIMCONU_16t = 0x0208,
+    LF_DIMCONLU_16t = 0x0209,
+    LF_DIMVARU_16t = 0x020a,
+    LF_DIMVARLU_16t = 0x020b,
+    LF_REFSYM = 0x020c,
+    LF_BCLASS_16t = 0x0400,
+    LF_VBCLASS_16t = 0x0401,
+    LF_IVBCLASS_16t = 0x0402,
+    LF_ENUMERATE_ST = 0x0403,
+    LF_FRIENDFCN_16t = 0x0404,
+    LF_INDEX_16t = 0x0405,
+    LF_MEMBER_16t = 0x0406,
+    LF_STMEMBER_16t = 0x0407,
+    LF_METHOD_16t = 0x0408,
+    LF_NESTTYPE_16t = 0x0409,
+    LF_VFUNCTAB_16t = 0x040a,
+    LF_FRIENDCLS_16t = 0x040b,
+    LF_ONEMETHOD_16t = 0x040c,
+    LF_VFUNCOFF_16t = 0x040d,
 
-    LF_SKIP             = 0x1200,
-    LF_ARGLIST          = 0x1201,
-    LF_DEFARG_ST        = 0x1202,
-    LF_FIELDLIST        = 0x1203,
-    LF_DERIVED          = 0x1204,
-    LF_BITFIELD         = 0x1205,
-    LF_METHODLIST       = 0x1206,
-    LF_DIMCONU          = 0x1207,
-    LF_DIMCONLU         = 0x1208,
-    LF_DIMVARU          = 0x1209,
-    LF_DIMVARLU         = 0x120a,
+    # 32-bit type index versions of leaves, all have the 0x1000 bit set
+    #
+    LF_TI16_MAX = 0x1000,
+    LF_MODIFIER = 0x1001,
+    LF_POINTER = 0x1002,
+    LF_ARRAY_ST = 0x1003,
+    LF_CLASS_ST = 0x1004,
+    LF_STRUCTURE_ST = 0x1005,
+    LF_UNION_ST = 0x1006,
+    LF_ENUM_ST = 0x1007,
+    LF_PROCEDURE = 0x1008,
+    LF_MFUNCTION = 0x1009,
+    LF_COBOL0 = 0x100a,
+    LF_BARRAY = 0x100b,
+    LF_DIMARRAY_ST = 0x100c,
+    LF_VFTPATH = 0x100d,
+    LF_PRECOMP_ST = 0x100e,  # not referenced from symbol
+    LF_OEM = 0x100f,  # oem definable type string
+    LF_ALIAS_ST = 0x1010,  # alias (typedef) type
+    LF_OEM2 = 0x1011,  # oem definable type string
 
-    LF_BCLASS           = 0x1400,
-    LF_VBCLASS          = 0x1401,
-    LF_IVBCLASS         = 0x1402,
-    LF_FRIENDFCN_ST     = 0x1403,
-    LF_INDEX            = 0x1404,
-    LF_MEMBER_ST        = 0x1405,
-    LF_STMEMBER_ST      = 0x1406,
-    LF_METHOD_ST        = 0x1407,
-    LF_NESTTYPE_ST      = 0x1408,
-    LF_VFUNCTAB         = 0x1409,
-    LF_FRIENDCLS        = 0x140a,
-    LF_ONEMETHOD_ST     = 0x140b,
-    LF_VFUNCOFF         = 0x140c,
-    LF_NESTTYPEEX_ST    = 0x140d,
-    LF_MEMBERMODIFY_ST  = 0x140e,
-    LF_MANAGED_ST       = 0x140f,
+    # leaf indices starting records but referenced only from type records
+    LF_SKIP = 0x1200,
+    LF_ARGLIST = 0x1201,
+    LF_DEFARG_ST = 0x1202,
+    LF_FIELDLIST = 0x1203,
+    LF_DERIVED = 0x1204,
+    LF_BITFIELD = 0x1205,
+    LF_METHODLIST = 0x1206,
+    LF_DIMCONU = 0x1207,
+    LF_DIMCONLU = 0x1208,
+    LF_DIMVARU = 0x1209,
+    LF_DIMVARLU = 0x120a,
+    LF_BCLASS = 0x1400,
+    LF_VBCLASS = 0x1401,
+    LF_IVBCLASS = 0x1402,
+    LF_FRIENDFCN_ST = 0x1403,
+    LF_INDEX = 0x1404,
+    LF_MEMBER_ST = 0x1405,
+    LF_STMEMBER_ST = 0x1406,
+    LF_METHOD_ST = 0x1407,
+    LF_NESTTYPE_ST = 0x1408,
+    LF_VFUNCTAB = 0x1409,
+    LF_FRIENDCLS = 0x140a,
+    LF_ONEMETHOD_ST = 0x140b,
+    LF_VFUNCOFF = 0x140c,
+    LF_NESTTYPEEX_ST = 0x140d,
+    LF_MEMBERMODIFY_ST = 0x140e,
+    LF_MANAGED_ST = 0x140f,
 
     # Types w/ SZ names
-
-    LF_ST_MAX           = 0x1500,
-
-    LF_TYPESERVER       = 0x1501,       # not referenced from symbol
-    LF_ENUMERATE        = 0x1502,
-    LF_ARRAY            = 0x1503,
-    LF_CLASS            = 0x1504,
-    LF_STRUCTURE        = 0x1505,
-    LF_UNION            = 0x1506,
-    LF_ENUM             = 0x1507,
-    LF_DIMARRAY         = 0x1508,
-    LF_PRECOMP          = 0x1509,       # not referenced from symbol
-    LF_ALIAS            = 0x150a,       # alias (typedef) type
-    LF_DEFARG           = 0x150b,
-    LF_FRIENDFCN        = 0x150c,
-    LF_MEMBER           = 0x150d,
-    LF_STMEMBER         = 0x150e,
-    LF_METHOD           = 0x150f,
-    LF_NESTTYPE         = 0x1510,
-    LF_ONEMETHOD        = 0x1511,
-    LF_NESTTYPEEX       = 0x1512,
-    LF_MEMBERMODIFY     = 0x1513,
-    LF_MANAGED          = 0x1514,
-    LF_TYPESERVER2      = 0x1515,
-
-    LF_STRIDED_ARRAY    = 0x1516,    # same as LF_ARRAY, but with stride between adjacent elements
-    LF_HLSL             = 0x1517,
-    LF_MODIFIER_EX      = 0x1518,
-    LF_INTERFACE        = 0x1519,
-    LF_BINTERFACE       = 0x151a,
-    LF_VECTOR           = 0x151b,
-    LF_MATRIX           = 0x151c,
-
-    LF_VFTABLE          = 0x151d,      # a virtual function table
+    LF_ST_MAX = 0x1500,
+    LF_TYPESERVER = 0x1501,  # not referenced from symbol
+    LF_ENUMERATE = 0x1502,
+    LF_ARRAY = 0x1503,
+    LF_CLASS = 0x1504,
+    LF_STRUCTURE = 0x1505,
+    LF_UNION = 0x1506,
+    LF_ENUM = 0x1507,
+    LF_DIMARRAY = 0x1508,
+    LF_PRECOMP = 0x1509,  # not referenced from symbol
+    LF_ALIAS = 0x150a,  # alias (typedef) type
+    LF_DEFARG = 0x150b,
+    LF_FRIENDFCN = 0x150c,
+    LF_MEMBER = 0x150d,
+    LF_STMEMBER = 0x150e,
+    LF_METHOD = 0x150f,
+    LF_NESTTYPE = 0x1510,
+    LF_ONEMETHOD = 0x1511,
+    LF_NESTTYPEEX = 0x1512,
+    LF_MEMBERMODIFY = 0x1513,
+    LF_MANAGED = 0x1514,
+    LF_TYPESERVER2 = 0x1515,
+    LF_STRIDED_ARRAY = 0x1516,  # same as LF_ARRAY, but with stride between adjacent elements
+    LF_HLSL = 0x1517,
+    LF_MODIFIER_EX = 0x1518,
+    LF_INTERFACE = 0x1519,
+    LF_BINTERFACE = 0x151a,
+    LF_VECTOR = 0x151b,
+    LF_MATRIX = 0x151c,
+    LF_VFTABLE = 0x151d,  # a virtual function table
     # LF_ENDOFLEAFRECORD  = 0x151d,
-
-    LF_TYPE_LAST        = 0x151d + 1, # one greater than the last type record
+    LF_TYPE_LAST = 0x151d + 1,  # one greater than the last type record
     # LF_TYPE_MAX         = (LF_TYPE_LAST) - 1,
-
-    LF_FUNC_ID          = 0x1601,    # global func ID
-    LF_MFUNC_ID         = 0x1602,    # member func ID
-    LF_BUILDINFO        = 0x1603,    # build info: tool, version, command line, src/pdb file
-    LF_SUBSTR_LIST      = 0x1604,    # similar to LF_ARGLIST, for list of sub strings
-    LF_STRING_ID        = 0x1605,    # string ID
-
-    LF_UDT_SRC_LINE     = 0x1606,    # source and line on where an UDT is defined
-                                     # only generated by compiler
-
-    LF_UDT_MOD_SRC_LINE = 0x1607,    # module, source and line on where an UDT is defined
-                                     # only generated by linker
-
-    LF_ID_LAST          = 0x1607 + 1, # one greater than the last ID record
+    LF_FUNC_ID = 0x1601,  # global func ID
+    LF_MFUNC_ID = 0x1602,  # member func ID
+    LF_BUILDINFO = 0x1603,  # build info: tool, version, command line, src/pdb file
+    LF_SUBSTR_LIST = 0x1604,  # similar to LF_ARGLIST, for list of sub strings
+    LF_STRING_ID = 0x1605,  # string ID
+    LF_UDT_SRC_LINE = 0x1606,  # source and line on where an UDT is defined
+    # only generated by compiler
+    LF_UDT_MOD_SRC_LINE = 0x1607,  # module, source and line on where an UDT is defined
+    # only generated by linker
+    LF_ID_LAST = 0x1607 + 1,  # one greater than the last ID record
     # LF_ID_MAX           = (LF_ID_MAX) - 1,
 
     # LF_NUMERIC          = 0x8000,
-    LF_CHAR             = 0x8000,
-    LF_SHORT            = 0x8001,
-    LF_USHORT           = 0x8002,
-    LF_LONG             = 0x8003,
-    LF_ULONG            = 0x8004,
-    LF_REAL32           = 0x8005,
-    LF_REAL64           = 0x8006,
-    LF_REAL80           = 0x8007,
-    LF_REAL128          = 0x8008,
-    LF_QUADWORD         = 0x8009,
-    LF_UQUADWORD        = 0x800a,
-    LF_REAL48           = 0x800b,
-    LF_COMPLEX32        = 0x800c,
-    LF_COMPLEX64        = 0x800d,
-    LF_COMPLEX80        = 0x800e,
-    LF_COMPLEX128       = 0x800f,
-    LF_VARSTRING        = 0x8010,
-
-    LF_OCTWORD          = 0x8017,
-    LF_UOCTWORD         = 0x8018,
-
-    LF_DECIMAL          = 0x8019,
-    LF_DATE             = 0x801a,
-    LF_UTF8STRING       = 0x801b,
-
-    LF_REAL16           = 0x801c,
-    
-    LF_PAD0             = 0xf0,
-    LF_PAD1             = 0xf1,
-    LF_PAD2             = 0xf2,
-    LF_PAD3             = 0xf3,
-    LF_PAD4             = 0xf4,
-    LF_PAD5             = 0xf5,
-    LF_PAD6             = 0xf6,
-    LF_PAD7             = 0xf7,
-    LF_PAD8             = 0xf8,
-    LF_PAD9             = 0xf9,
-    LF_PAD10            = 0xfa,
-    LF_PAD11            = 0xfb,
-    LF_PAD12            = 0xfc,
-    LF_PAD13            = 0xfd,
-    LF_PAD14            = 0xfe,
-    LF_PAD15            = 0xff,
+    LF_CHAR = 0x8000,
+    LF_SHORT = 0x8001,
+    LF_USHORT = 0x8002,
+    LF_LONG = 0x8003,
+    LF_ULONG = 0x8004,
+    LF_REAL32 = 0x8005,
+    LF_REAL64 = 0x8006,
+    LF_REAL80 = 0x8007,
+    LF_REAL128 = 0x8008,
+    LF_QUADWORD = 0x8009,
+    LF_UQUADWORD = 0x800a,
+    LF_REAL48 = 0x800b,
+    LF_COMPLEX32 = 0x800c,
+    LF_COMPLEX64 = 0x800d,
+    LF_COMPLEX80 = 0x800e,
+    LF_COMPLEX128 = 0x800f,
+    LF_VARSTRING = 0x8010,
+    LF_OCTWORD = 0x8017,
+    LF_UOCTWORD = 0x8018,
+    LF_DECIMAL = 0x8019,
+    LF_DATE = 0x801a,
+    LF_UTF8STRING = 0x801b,
+    LF_REAL16 = 0x801c,
+    LF_PAD0 = 0xf0,
+    LF_PAD1 = 0xf1,
+    LF_PAD2 = 0xf2,
+    LF_PAD3 = 0xf3,
+    LF_PAD4 = 0xf4,
+    LF_PAD5 = 0xf5,
+    LF_PAD6 = 0xf6,
+    LF_PAD7 = 0xf7,
+    LF_PAD8 = 0xf8,
+    LF_PAD9 = 0xf9,
+    LF_PAD10 = 0xfa,
+    LF_PAD11 = 0xfb,
+    LF_PAD12 = 0xfc,
+    LF_PAD13 = 0xfd,
+    LF_PAD14 = 0xfe,
+    LF_PAD15 = 0xff,
 )
 
 ### CodeView bitfields and enums
 # NOTE: Construct assumes big-endian
 # ordering for BitStructs
-CV_fldattr = BitStruct("fldattr",
+CV_fldattr = BitStruct(
+    "fldattr",
     Flag("noconstruct"),
     Flag("noinherit"),
     Flag("pseudo"),
-    Enum(BitField("mprop", 3),
-        MTvanilla   = 0x00,
-        MTvirtual   = 0x01,
-        MTstatic    = 0x02,
-        MTfriend    = 0x03,
-        MTintro     = 0x04,
-        MTpurevirt  = 0x05,
+    Enum(
+        BitField("mprop", 3),
+        MTvanilla = 0x00,
+        MTvirtual = 0x01,
+        MTstatic = 0x02,
+        MTfriend = 0x03,
+        MTintro = 0x04,
+        MTpurevirt = 0x05,
         MTpureintro = 0x06,
-        _default_   = Pass,
+        _default_ = Pass,
     ),
-    Enum(BitField("access", 2),
-        private    = 1,
-        protected  = 2,
-        public     = 3,
-        _default_  = Pass,
+    Enum(
+        BitField("access", 2),
+        private = 1,
+        protected = 2,
+        public = 3,
+        _default_ = Pass,
     ),
-
     Padding(7),
     Flag("compgenx"),
 )
 
-CV_call = Enum(ULInt8("call_conv"),
-    NEAR_C          = 0x00000000,
-    FAR_C           = 0x00000001,
-    NEAR_PASCAL     = 0x00000002,
-    FAR_PASCAL      = 0x00000003,
-    NEAR_FAST       = 0x00000004,
-    FAR_FAST        = 0x00000005,
-    SKIPPED         = 0x00000006,
-    NEAR_STD        = 0x00000007,
-    FAR_STD         = 0x00000008,
-    NEAR_SYS        = 0x00000009,
-    FAR_SYS         = 0x0000000A,
-    THISCALL        = 0x0000000B,
-    MIPSCALL        = 0x0000000C,
-    GENERIC         = 0x0000000D,
-    ALPHACALL       = 0x0000000E,
-    PPCCALL         = 0x0000000F,
-    SHCALL          = 0x00000010,
-    ARMCALL         = 0x00000011,
-    AM33CALL        = 0x00000012,
-    TRICALL         = 0x00000013,
-    SH5CALL         = 0x00000014,
-    M32RCALL        = 0x00000015,
-    RESERVED        = 0x00000016,
-    _default_       = Pass,
+CV_call = Enum(
+    ULInt8("call_conv"),
+    NEAR_C = 0x00000000,
+    FAR_C = 0x00000001,
+    NEAR_PASCAL = 0x00000002,
+    FAR_PASCAL = 0x00000003,
+    NEAR_FAST = 0x00000004,
+    FAR_FAST = 0x00000005,
+    SKIPPED = 0x00000006,
+    NEAR_STD = 0x00000007,
+    FAR_STD = 0x00000008,
+    NEAR_SYS = 0x00000009,
+    FAR_SYS = 0x0000000A,
+    THISCALL = 0x0000000B,
+    MIPSCALL = 0x0000000C,
+    GENERIC = 0x0000000D,
+    ALPHACALL = 0x0000000E,
+    PPCCALL = 0x0000000F,
+    SHCALL = 0x00000010,
+    ARMCALL = 0x00000011,
+    AM33CALL = 0x00000012,
+    TRICALL = 0x00000013,
+    SH5CALL = 0x00000014,
+    M32RCALL = 0x00000015,
+    RESERVED = 0x00000016,
+    _default_ = Pass,
 )
 
-CV_property = BitStruct("prop",
+CV_property = BitStruct(
+    "prop",
     Flag("fwdref"),
     Flag("opcast"),
     Flag("opassign"),
@@ -747,54 +666,68 @@ CV_property = BitStruct("prop",
     Flag("ovlops"),
     Flag("ctor"),
     Flag("packed"),
-
-    BitField("reserved", 7, swapped=True),
+    BitField("reserved", 7, swapped = True),
     Flag("scoped"),
 )
 
+
 def val(name):
-    return Struct("value",
+    return Struct(
+        "value",
         Value("_value_name", lambda ctx: name),
         ULInt16("value_or_type"),
-        IfThenElse("name_or_val", lambda ctx: ctx.value_or_type < leaf_type._encode("LF_CHAR",ctx),
-            CString("name", encoding="utf8"),
-            Switch("val", lambda ctx: leaf_type._decode(ctx.value_or_type, {}),
+        IfThenElse(
+            "name_or_val",
+            lambda ctx: ctx.value_or_type < leaf_type._encode("LF_CHAR", ctx),
+            CString("name", encoding = "utf8"),
+            Switch(
+                "val",
+                lambda ctx: leaf_type._decode(ctx.value_or_type, {}),
                 {
-                    "LF_CHAR": Struct("char",
+                    "LF_CHAR": Struct(
+                        "char",
                         SLInt8("value"),
-                        CString("name", encoding="utf8"),
+                        CString("name", encoding = "utf8"),
                     ),
-                    "LF_SHORT": Struct("short",
+                    "LF_SHORT": Struct(
+                        "short",
                         SLInt16("value"),
-                        CString("name", encoding="utf8"),
+                        CString("name", encoding = "utf8"),
                     ),
-                    "LF_USHORT": Struct("ushort",
+                    "LF_USHORT": Struct(
+                        "ushort",
                         ULInt16("value"),
-                        CString("name", encoding="utf8"),
+                        CString("name", encoding = "utf8"),
                     ),
-                    "LF_LONG": Struct("char",
+                    "LF_LONG": Struct(
+                        "char",
                         SLInt32("value"),
-                        CString("name", encoding="utf8"),
+                        CString("name", encoding = "utf8"),
                     ),
-                    "LF_ULONG": Struct("char",
+                    "LF_ULONG": Struct(
+                        "char",
                         ULInt32("value"),
-                        CString("name", encoding="utf8"),
+                        CString("name", encoding = "utf8"),
                     ),
                 },
             ),
         ),
     )
 
-PadAlign = If(lambda ctx: ctx._pad != None and ctx._pad > 0xF0,
-    Optional(Padding(lambda ctx: ctx._pad & 0x0F))
-)
+
+PadAlign = If(lambda ctx: ctx._pad != None and ctx._pad > 0xF0, Optional(Padding(lambda ctx: ctx._pad & 0x0F)))
 
 ### Leaf types
-subStruct = Struct("substructs",
+subStruct = Struct(
+    "substructs",
     leaf_type,
-    Switch("type_info", lambda ctx: ctx.leaf_type,
+    Switch(
+        "type_info",
+        lambda ctx: ctx.leaf_type,
         {
-            "LF_MEMBER_ST": Struct("lfMemberST",
+            "LF_MEMBER_ST":
+            Struct(
+                "lfMemberST",
                 CV_fldattr,
                 ULInt32("index"),
                 ULInt16("offset"),
@@ -802,82 +735,100 @@ subStruct = Struct("substructs",
                 Peek(ULInt8("_pad")),
                 PadAlign,
             ),
-            "LF_MEMBER": Struct("lfMember",
+            "LF_MEMBER":
+            Struct(
+                "lfMember",
                 CV_fldattr,
                 ULInt32("index"),
                 val("offset"),
                 Peek(ULInt8("_pad")),
                 PadAlign,
             ),
-            "LF_ENUMERATE": Struct("lfEnumerate",
+            "LF_ENUMERATE":
+            Struct(
+                "lfEnumerate",
                 CV_fldattr,
                 val("enum_value"),
                 Peek(ULInt8("_pad")),
                 PadAlign,
             ),
-            "LF_BCLASS": Struct("lfBClass",
+            "LF_BCLASS":
+            Struct(
+                "lfBClass",
                 CV_fldattr,
                 ULInt32("index"),
                 val("offset"),
                 Peek(ULInt8("_pad")),
                 PadAlign,
             ),
-            "LF_VFUNCTAB": Struct("lfVFuncTab",
+            "LF_VFUNCTAB":
+            Struct(
+                "lfVFuncTab",
                 Padding(2),
                 ULInt32("type"),
                 Peek(ULInt8("_pad")),
                 PadAlign,
             ),
-            "LF_ONEMETHOD": Struct("lfOneMethod",
+            "LF_ONEMETHOD":
+            Struct(
+                "lfOneMethod",
                 CV_fldattr,
                 ULInt32("index"),
-                Switch("intro", lambda ctx: ctx.fldattr.mprop,
+                Switch(
+                    "intro",
+                    lambda ctx: ctx.fldattr.mprop,
                     {
-                        "MTintro": Struct("value",
+                        "MTintro": Struct(
+                            "value",
                             ULInt32("val"),
-                            CString("str_data", encoding="utf8"),
+                            CString("str_data", encoding = "utf8"),
                         ),
-                        "MTpureintro": Struct("value",
+                        "MTpureintro": Struct(
+                            "value",
                             ULInt32("val"),
-                            CString("str_data", encoding="utf8"),
+                            CString("str_data", encoding = "utf8"),
                         ),
                     },
-                    default = CString("str_data", encoding="utf8"),
+                    default = CString("str_data", encoding = "utf8"),
                 ),
                 Peek(ULInt8("_pad")),
                 PadAlign,
             ),
-            "LF_METHOD": Struct("lfMethod",
+            "LF_METHOD":
+            Struct(
+                "lfMethod",
                 ULInt16("count"),
                 ULInt32("mlist"),
-                CString("name", encoding="utf8"),
+                CString("name", encoding = "utf8"),
                 Peek(ULInt8("_pad")),
                 PadAlign,
             ),
-            "LF_NESTTYPE": Struct("lfNestType",
+            "LF_NESTTYPE":
+            Struct(
+                "lfNestType",
                 Padding(2),
                 ULInt32("index"),
-                CString("name", encoding="utf8"),
+                CString("name", encoding = "utf8"),
             ),
         },
     ),
 )
 
-lfFieldList = Struct("lfFieldList",
-    OptionalGreedyRange(subStruct)
-)
+lfFieldList = Struct("lfFieldList", OptionalGreedyRange(subStruct))
 
-lfEnum = Struct("lfEnum",
+lfEnum = Struct(
+    "lfEnum",
     ULInt16("count"),
     CV_property,
     ULInt32("utype"),
     ULInt32("fieldlist"),
-    CString("name", encoding="utf8"),
+    CString("name", encoding = "utf8"),
     Peek(ULInt8("_pad")),
     PadAlign,
 )
 
-lfBitfield = Struct("lfBitfield",
+lfBitfield = Struct(
+    "lfBitfield",
     ULInt32("base_type"),
     ULInt8("length"),
     ULInt8("position"),
@@ -885,7 +836,8 @@ lfBitfield = Struct("lfBitfield",
     PadAlign,
 )
 
-lfStructureST = Struct("lfStructureST",
+lfStructureST = Struct(
+    "lfStructureST",
     ULInt16("count"),
     CV_property,
     ULInt32("fieldlist"),
@@ -897,7 +849,8 @@ lfStructureST = Struct("lfStructureST",
     PadAlign,
 )
 
-lfStructure = Struct("lfStructure",
+lfStructure = Struct(
+    "lfStructure",
     ULInt16("count"),
     CV_property,
     ULInt32("fieldlist"),
@@ -910,7 +863,8 @@ lfStructure = Struct("lfStructure",
 
 lfClass = Rename("lfClass", lfStructure)
 
-lfArray = Struct("lfArray",
+lfArray = Struct(
+    "lfArray",
     ULInt32("element_type"),
     ULInt32("index_type"),
     val("size"),
@@ -918,7 +872,8 @@ lfArray = Struct("lfArray",
     PadAlign,
 )
 
-lfArrayST = Struct("lfArray",
+lfArrayST = Struct(
+    "lfArray",
     ULInt32("element_type"),
     ULInt32("index_type"),
     ULInt16("size"),
@@ -927,14 +882,16 @@ lfArrayST = Struct("lfArray",
     PadAlign,
 )
 
-lfArgList = Struct("lfArgList",
+lfArgList = Struct(
+    "lfArgList",
     ULInt32("count"),
     Array(lambda ctx: ctx.count, ULInt32("arg_type")),
     Peek(ULInt8("_pad")),
     PadAlign,
 )
 
-lfProcedure = Struct("lfProcedure",
+lfProcedure = Struct(
+    "lfProcedure",
     ULInt32("return_type"),
     CV_call,
     ULInt8("reserved"),
@@ -944,9 +901,11 @@ lfProcedure = Struct("lfProcedure",
     PadAlign,
 )
 
-lfModifier = Struct("lfModifier",
+lfModifier = Struct(
+    "lfModifier",
     ULInt32("modified_type"),
-    BitStruct("modifier",
+    BitStruct(
+        "modifier",
         Padding(5),
         Flag("unaligned"),
         Flag("volatile"),
@@ -957,31 +916,35 @@ lfModifier = Struct("lfModifier",
     PadAlign,
 )
 
-lfPointer = Struct("lfPointer",
+lfPointer = Struct(
+    "lfPointer",
     ULInt32("utype"),
-    BitStruct("ptr_attr",
-        Enum(BitField("mode", 3),
-            PTR_MODE_PTR         = 0x00000000,
-            PTR_MODE_REF         = 0x00000001,
-            PTR_MODE_PMEM        = 0x00000002,
-            PTR_MODE_PMFUNC      = 0x00000003,
-            PTR_MODE_RESERVED    = 0x00000004,
+    BitStruct(
+        "ptr_attr",
+        Enum(
+            BitField("mode", 3),
+            PTR_MODE_PTR = 0x00000000,
+            PTR_MODE_REF = 0x00000001,
+            PTR_MODE_PMEM = 0x00000002,
+            PTR_MODE_PMFUNC = 0x00000003,
+            PTR_MODE_RESERVED = 0x00000004,
         ),
-        Enum(BitField("type", 5),
-            PTR_NEAR             = 0x00000000,
-            PTR_FAR              = 0x00000001,
-            PTR_HUGE             = 0x00000002,
-            PTR_BASE_SEG         = 0x00000003,
-            PTR_BASE_VAL         = 0x00000004,
-            PTR_BASE_SEGVAL      = 0x00000005,
-            PTR_BASE_ADDR        = 0x00000006,
-            PTR_BASE_SEGADDR     = 0x00000007,
-            PTR_BASE_TYPE        = 0x00000008,
-            PTR_BASE_SELF        = 0x00000009,
-            PTR_NEAR32           = 0x0000000A,
-            PTR_FAR32            = 0x0000000B,
-            PTR_64               = 0x0000000C,
-            PTR_UNUSEDPTR        = 0x0000000D,
+        Enum(
+            BitField("type", 5),
+            PTR_NEAR = 0x00000000,
+            PTR_FAR = 0x00000001,
+            PTR_HUGE = 0x00000002,
+            PTR_BASE_SEG = 0x00000003,
+            PTR_BASE_VAL = 0x00000004,
+            PTR_BASE_SEGVAL = 0x00000005,
+            PTR_BASE_ADDR = 0x00000006,
+            PTR_BASE_SEGADDR = 0x00000007,
+            PTR_BASE_TYPE = 0x00000008,
+            PTR_BASE_SELF = 0x00000009,
+            PTR_NEAR32 = 0x0000000A,
+            PTR_FAR32 = 0x0000000B,
+            PTR_64 = 0x0000000C,
+            PTR_UNUSEDPTR = 0x0000000D,
         ),
         Padding(3),
         Flag("restrict"),
@@ -995,7 +958,8 @@ lfPointer = Struct("lfPointer",
     PadAlign,
 )
 
-lfUnion = Struct("lfUnion",
+lfUnion = Struct(
+    "lfUnion",
     ULInt16("count"),
     CV_property,
     ULInt32("fieldlist"),
@@ -1004,7 +968,8 @@ lfUnion = Struct("lfUnion",
     PadAlign,
 )
 
-lfUnionST = Struct("lfUnionST",
+lfUnionST = Struct(
+    "lfUnionST",
     ULInt16("count"),
     CV_property,
     ULInt32("fieldlist"),
@@ -1014,7 +979,8 @@ lfUnionST = Struct("lfUnionST",
     PadAlign,
 )
 
-lfMFunc = Struct("lfMFunc",
+lfMFunc = Struct(
+    "lfMFunc",
     ULInt32("return_type"),
     ULInt32("class_type"),
     ULInt32("this_type"),
@@ -1025,14 +991,14 @@ lfMFunc = Struct("lfMFunc",
     SLInt32("thisadjust"),
     Peek(ULInt8("_pad")),
     PadAlign,
-) 
+)
 
-lfVTShape = Struct("lfVTShape",
+lfVTShape = Struct(
+    "lfVTShape",
     ULInt16("count"),
-    BitStruct("vt_descriptors",
-        Array(lambda ctx: ctx._.count,
-            BitField("vt_descriptors", 4)
-        ),
+    BitStruct(
+        "vt_descriptors",
+        Array(lambda ctx: ctx._.count, BitField("vt_descriptors", 4)),
         # Needed to align to a byte boundary
         Padding(lambda ctx: (ctx._.count % 2) * 4),
     ),
@@ -1040,32 +1006,37 @@ lfVTShape = Struct("lfVTShape",
     PadAlign,
 )
 
-Type = Debugger(Struct("type",
-    leaf_type,
-    Switch("type_info", lambda ctx: ctx.leaf_type,
-        {
-            "LF_ARGLIST": lfArgList,
-            "LF_ARRAY": lfArray,
-            "LF_ARRAY_ST": lfArrayST,
-            "LF_BITFIELD": lfBitfield,
-            "LF_CLASS": lfClass,
-            "LF_ENUM": lfEnum,
-            "LF_FIELDLIST": lfFieldList,
-            "LF_MFUNCTION": lfMFunc,
-            "LF_MODIFIER": lfModifier,
-            "LF_POINTER": lfPointer,
-            "LF_PROCEDURE": lfProcedure,
-            "LF_STRUCTURE": lfStructure,
-            "LF_STRUCTURE_ST": lfStructureST,
-            "LF_UNION": lfUnion,
-            "LF_UNION_ST": lfUnionST,
-            "LF_VTSHAPE": lfVTShape,
-        },
-        default = Pass,
-    ),
-))
+Type = Debugger(
+    Struct(
+        "type",
+        leaf_type,
+        Switch(
+            "type_info",
+            lambda ctx: ctx.leaf_type,
+            {
+                "LF_ARGLIST": lfArgList,
+                "LF_ARRAY": lfArray,
+                "LF_ARRAY_ST": lfArrayST,
+                "LF_BITFIELD": lfBitfield,
+                "LF_CLASS": lfClass,
+                "LF_ENUM": lfEnum,
+                "LF_FIELDLIST": lfFieldList,
+                "LF_MFUNCTION": lfMFunc,
+                "LF_MODIFIER": lfModifier,
+                "LF_POINTER": lfPointer,
+                "LF_PROCEDURE": lfProcedure,
+                "LF_STRUCTURE": lfStructure,
+                "LF_STRUCTURE_ST": lfStructureST,
+                "LF_UNION": lfUnion,
+                "LF_UNION_ST": lfUnionST,
+                "LF_VTSHAPE": lfVTShape,
+            },
+            default = Pass,
+        ),
+    ))
 
-Types = Struct("types",
+Types = Struct(
+    "types",
     ULInt16("length"),
     Tunnel(
         String("type_data", lambda ctx: ctx.length),
@@ -1073,14 +1044,18 @@ Types = Struct("types",
     ),
 )
 
+
 ### Header structures
 def OffCb(name):
-    return Struct(name,
+    return Struct(
+        name,
         SLInt32("off"),
         SLInt32("cb"),
     )
 
-TPI = Struct("TPIHash",
+
+TPI = Struct(
+    "TPIHash",
     ULInt16("sn"),
     Padding(2),
     SLInt32("HashKey"),
@@ -1090,7 +1065,8 @@ TPI = Struct("TPIHash",
     OffCb("HashAdj"),
 )
 
-Header = Struct("TPIHeader",
+Header = Struct(
+    "TPIHeader",
     ULInt32("version"),
     SLInt32("hdr_size"),
     ULInt32("ti_min"),
@@ -1100,12 +1076,14 @@ Header = Struct("TPIHeader",
 )
 
 ### Stream as a whole
-TPIStream = Struct("TPIStream",
+TPIStream = Struct(
+    "TPIStream",
     Header,
     Array(lambda ctx: ctx.TPIHeader.ti_max - ctx.TPIHeader.ti_min, Types),
 )
 
 ### END PURE CONSTRUCT DATA ###
+
 
 # FIXME: this should not be necessary if we use the Embed construct
 def merge_subcon(parent, subattr):
@@ -1122,6 +1100,7 @@ def merge_subcon(parent, subattr):
         setattr(parent, a, getattr(subcon, a))
 
     delattr(parent, subattr)
+
 
 def fix_value(leaf):
     """Translate the value member of a leaf node into a nicer form.
@@ -1146,7 +1125,7 @@ def fix_value(leaf):
     The value is named according to the string in _value_name.
     """
     if not hasattr(leaf, 'value'): return
-    if leaf.value.value_or_type < leaf_type._encode("LF_CHAR",{}):
+    if leaf.value.value_or_type < leaf_type._encode("LF_CHAR", {}):
         setattr(leaf, 'name', leaf.value.name_or_val)
         setattr(leaf, leaf.value._value_name, leaf.value.value_or_type)
     else:
@@ -1154,6 +1133,7 @@ def fix_value(leaf):
         setattr(leaf, leaf.value._value_name, leaf.value.name_or_val.value)
 
     delattr(leaf, 'value')
+
 
 def resolve_typerefs(leaf, types, min):
     """Resolve the numeric type references in a leaf node.
@@ -1173,19 +1153,21 @@ def resolve_typerefs(leaf, types, min):
             newrefs = []
             for r in ref:
                 if r < min:
-                    newrefs.append(base_type._decode(r,{}))
+                    newrefs.append(base_type._decode(r, {}))
                 else:
                     newrefs.append(types[r])
             newrefs = ListContainer(newrefs)
             setattr(leaf, attr, newrefs)
         else:
             if ref < min:
-                setattr(leaf, attr, base_type._decode(ref,{}))
+                setattr(leaf, attr, base_type._decode(ref, {}))
             elif ref >= min:
                 try:
                     setattr(leaf, attr, types[ref])
-                except KeyError: pass
+                except KeyError:
+                    pass
     return leaf
+
 
 def merge_fwdrefs(leaf, types, map):
     for attr in type_refs[leaf.leaf_type]:
@@ -1193,21 +1175,27 @@ def merge_fwdrefs(leaf, types, map):
         if isinstance(ref, list):
             newrefs = []
             for r in ref:
-                try: newrefs.append(types[map[r.tpi_idx]])
-                except (KeyError, AttributeError): newrefs.append(r)
+                try:
+                    newrefs.append(types[map[r.tpi_idx]])
+                except (KeyError, AttributeError):
+                    newrefs.append(r)
             newrefs = ListContainer(newrefs)
             setattr(leaf, attr, newrefs)
-        elif not isinstance(ref,str):
-            try: newref = types[map[ref.tpi_idx]]
-            except (KeyError, AttributeError): newref = ref
+        elif not isinstance(ref, str):
+            try:
+                newref = types[map[ref.tpi_idx]]
+            except (KeyError, AttributeError):
+                newref = ref
             setattr(leaf, attr, newref)
     return leaf
+
 
 def rename_2_7(lf):
     if lf.leaf_type.endswith("_ST"):
         lf.leaf_type = lf.leaf_type[:-3]
 
-def parse_stream(fp, unnamed_hack=True, elim_fwdrefs=True):
+
+def parse_stream(fp, unnamed_hack = True, elim_fwdrefs = True):
     """Parse a TPI stream.
 
     fp: a file-like object that holds the type data to be parsed. Must
@@ -1215,24 +1203,21 @@ def parse_stream(fp, unnamed_hack=True, elim_fwdrefs=True):
 
     """
     tpi_stream = TPIStream.parse_stream(fp)
-    
+
     # Postprocessing
     # 1. Index the types
     tpi_stream.types = dict(
-        (i, t) for (i,t) in zip(
-            range(tpi_stream.TPIHeader.ti_min, tpi_stream.TPIHeader.ti_max),
-            tpi_stream.types
-        )
-    )
-    for k in tpi_stream.types: tpi_stream.types[k].tpi_idx = k
+        (i, t) for (i, t) in zip(range(tpi_stream.TPIHeader.ti_min, tpi_stream.TPIHeader.ti_max), tpi_stream.types))
+    for k in tpi_stream.types:
+        tpi_stream.types[k].tpi_idx = k
 
     # 2. Flatten type_info and type_data
     for t in tpi_stream.types.values():
-        merge_subcon(t,'type_data')
-        merge_subcon(t,'type_info')
+        merge_subcon(t, 'type_data')
+        merge_subcon(t, 'type_info')
         if t.leaf_type == 'LF_FIELDLIST':
             for s in t.substructs:
-                merge_subcon(s,'type_info')
+                merge_subcon(s, 'type_info')
 
     # 3. Fix up value and name structures
     for t in tpi_stream.types.values():
@@ -1247,17 +1232,16 @@ def parse_stream(fp, unnamed_hack=True, elim_fwdrefs=True):
     min = tpi_stream.TPIHeader.ti_min
     for i in types:
         if types[i].leaf_type == "LF_FIELDLIST":
-            types[i].substructs = ListContainer([ 
-                resolve_typerefs(t, types, min) for t in types[i].substructs
-            ])
+            types[i].substructs = ListContainer([resolve_typerefs(t, types, min) for t in types[i].substructs])
         else:
             types[i] = resolve_typerefs(types[i], types, min)
-    
+
     # 5. Standardize v2 leaf names to v7 convention
     for i in types:
         rename_2_7(types[i])
         if types[i].leaf_type == "LF_FIELDLIST":
-            for s in types[i].substructs: rename_2_7(s)
+            for s in types[i].substructs:
+                rename_2_7(s)
 
     # 6. Attempt to eliminate forward refs
     # Not possible to eliminate all fwdrefs; some may not be in
@@ -1271,33 +1255,31 @@ def parse_stream(fp, unnamed_hack=True, elim_fwdrefs=True):
         # Map them to the real type
         fwdref_map = {}
         for i in types:
-            if (hasattr(types[i], 'name') and hasattr(types[i], 'prop') and
-                not types[i].prop.fwdref):
+            if (hasattr(types[i], 'name') and hasattr(types[i], 'prop') and not types[i].prop.fwdref):
                 if types[i].name in fwdrefs:
                     fwdref_map[fwdrefs[types[i].name]] = types[i].tpi_idx
         # Change any references to the fwdref to point to the real type
         for i in types:
             if types[i].leaf_type == "LF_FIELDLIST":
-                types[i].substructs = ListContainer([ 
-                    merge_fwdrefs(t, types, fwdref_map) for t in types[i].substructs
-                ])
+                types[i].substructs = ListContainer([merge_fwdrefs(t, types, fwdref_map) for t in types[i].substructs])
             else:
                 types[i] = merge_fwdrefs(types[i], types, fwdref_map)
         # Get rid of the resolved fwdrefs
-        for i in fwdref_map: del types[i]
+        for i in fwdref_map:
+            del types[i]
 
     if unnamed_hack:
         for i in types:
-            if (hasattr(types[i], 'name') and
-                    (types[i].name == "__unnamed" or
-                     types[i].name == "<unnamed-tag>")):
+            if (hasattr(types[i], 'name') and (types[i].name == "__unnamed" or types[i].name == "<unnamed-tag>")):
                 types[i].name = ("__unnamed_%x" % types[i].tpi_idx)
 
     return tpi_stream
 
-def parse(data, unnamed_hack=True, elim_fwdrefs=True):
+
+def parse(data, unnamed_hack = True, elim_fwdrefs = True):
     return parse_stream(BytesIO(data), unnamed_hack, elim_fwdrefs)
-    
+
+
 if __name__ == "__main__":
     import sys
     import time
@@ -1307,7 +1289,7 @@ if __name__ == "__main__":
         tpi_stream = parse_stream(stream)
 
     ed = time.time()
-    print ("Parsed %d types in %f seconds" % (len(tpi_stream.types), ed - st))
+    print("Parsed %d types in %f seconds" % (len(tpi_stream.types), ed - st))
 
     #for k,v in tpi_stream.types.items():
     #    print (k,v)

--- a/pdbparse/undecorate.py
+++ b/pdbparse/undecorate.py
@@ -2,6 +2,7 @@
 
 prefixes = "__imp__", "__imp_@", "__imp_", "_", "@", "\x7F"
 
+
 def undecorate(name):
     stack = -1
     conv = "UNDEFINED"
@@ -10,10 +11,10 @@ def undecorate(name):
         if name.startswith(p):
             name = name[len(p):]
             break
-    
+
     if name.startswith("@@") or name.startswith("?"):
         name = orig_name
-    else: 
+    else:
         name_parts = name.split("@")
         if len(name_parts) == 2:
             try:

--- a/pdbparse/undname.py
+++ b/pdbparse/undname.py
@@ -1,31 +1,31 @@
 import os
-from . import _undname # automatically resolve and load shared library (_undame.pyd or _undame.so)
+from . import _undname  # automatically resolve and load shared library (_undame.pyd or _undame.so)
+
+UNDNAME_COMPLETE = 0x0000
+UNDNAME_NO_LEADING_UNDERSCORES = 0x0001  # Don't show __ in calling convention
+UNDNAME_NO_MS_KEYWORDS = 0x0002  # Don't show calling convention at all
+UNDNAME_NO_FUNCTION_RETURNS = 0x0004  # Don't show function/method return value
+UNDNAME_NO_ALLOCATION_MODEL = 0x0008
+UNDNAME_NO_ALLOCATION_LANGUAGE = 0x0010
+UNDNAME_NO_MS_THISTYPE = 0x0020
+UNDNAME_NO_CV_THISTYPE = 0x0040
+UNDNAME_NO_THISTYPE = 0x0060
+UNDNAME_NO_ACCESS_SPECIFIERS = 0x0080  # Don't show access specifier public/protected/private
+UNDNAME_NO_THROW_SIGNATURES = 0x0100
+UNDNAME_NO_MEMBER_TYPE = 0x0200  # Don't show static/virtual specifier
+UNDNAME_NO_RETURN_UDT_MODEL = 0x0400
+UNDNAME_32_BIT_DECODE = 0x0800
+UNDNAME_NAME_ONLY = 0x1000  # Only report the variable/method name
+UNDNAME_NO_ARGUMENTS = 0x2000  # Don't show method arguments
+UNDNAME_NO_SPECIAL_SYMS = 0x4000
+UNDNAME_NO_COMPLEX_TYPE = 0x8000
 
 
-UNDNAME_COMPLETE                 = 0x0000
-UNDNAME_NO_LEADING_UNDERSCORES   = 0x0001 # Don't show __ in calling convention
-UNDNAME_NO_MS_KEYWORDS           = 0x0002 # Don't show calling convention at all
-UNDNAME_NO_FUNCTION_RETURNS      = 0x0004 # Don't show function/method return value
-UNDNAME_NO_ALLOCATION_MODEL      = 0x0008
-UNDNAME_NO_ALLOCATION_LANGUAGE   = 0x0010
-UNDNAME_NO_MS_THISTYPE           = 0x0020
-UNDNAME_NO_CV_THISTYPE           = 0x0040
-UNDNAME_NO_THISTYPE              = 0x0060
-UNDNAME_NO_ACCESS_SPECIFIERS     = 0x0080 # Don't show access specifier public/protected/private
-UNDNAME_NO_THROW_SIGNATURES      = 0x0100
-UNDNAME_NO_MEMBER_TYPE           = 0x0200 # Don't show static/virtual specifier
-UNDNAME_NO_RETURN_UDT_MODEL      = 0x0400
-UNDNAME_32_BIT_DECODE            = 0x0800
-UNDNAME_NAME_ONLY                = 0x1000 # Only report the variable/method name
-UNDNAME_NO_ARGUMENTS             = 0x2000 # Don't show method arguments
-UNDNAME_NO_SPECIAL_SYMS          = 0x4000
-UNDNAME_NO_COMPLEX_TYPE          = 0x8000
+def undname(name, flags = UNDNAME_NAME_ONLY):
 
-def undname(name, flags=UNDNAME_NAME_ONLY):
-  
     if name.startswith("?"):
         name = _undname.undname(name, flags)
     elif name.startswith("_") or name.startswith("@"):
-        name = name.rsplit('@',1)[0][1:]
+        name = name.rsplit('@', 1)[0][1:]
 
     return name

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,24 @@
 
 from distutils.core import setup, Extension
 
-setup(name='pdbparse',
-      version='1.1',
-      description='Python parser for Microsoft PDB files',
-      author='Brendan Dolan-Gavitt',
-      author_email='brendandg@gatech.edu',
-      url='http://pdbparse.googlecode.com/',
-      packages=['pdbparse'],
-      install_requires = [
-        'construct<=2.5.2', # last known release from https://github.com/tomerfiliba
+setup(
+    name = 'pdbparse',
+    version = '1.1',
+    description = 'Python parser for Microsoft PDB files',
+    author = 'Brendan Dolan-Gavitt',
+    author_email = 'brendandg@gatech.edu',
+    url = 'http://pdbparse.googlecode.com/',
+    packages = ['pdbparse'],
+    install_requires = [
+        'construct<=2.5.2',  # last known release from https://github.com/tomerfiliba
         'pefile'
-      ],
-      classifiers=[
+    ],
+    classifiers = [
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Operating System :: OS Independent',
-      ],
-      ext_modules=[
-        Extension('pdbparse._undname', sources = ['src/undname.c', 'src/undname_py.c'])
-      ],
-      scripts=[
+    ],
+    ext_modules = [Extension('pdbparse._undname', sources = ['src/undname.c', 'src/undname_py.c'])],
+    scripts = [
         'examples/pdb_dump.py',
         'examples/pdb_get_syscall_table.py',
         'examples/pdb_lookup.py',
@@ -29,5 +28,4 @@ setup(name='pdbparse',
         'examples/pdb_print_tpi.py',
         'examples/pdb_tpi_vtypes.py',
         'examples/symchk.py',
-      ]
-     )
+    ])

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,7 @@ setup(
     author_email = 'brendandg@gatech.edu',
     url = 'http://pdbparse.googlecode.com/',
     packages = ['pdbparse'],
-    install_requires = [
-        'construct<=2.5.2',  # last known release from https://github.com/tomerfiliba
-        'pefile'
-    ],
+    install_requires = ['=construct-2.9', 'pefile'],
     classifiers = [
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Most of this is straight-forward following the transition guides for construct -2.8 and -2.9.

There was one tricky part that was pointed out in issue #45 , which was the combination of Embedding and Switches, as well as the Tunnelling.  Tunnelling is replaced by RestreamData and there is a thing called an EmbeddedSwitch, but unfortunately the current contributor supporting Construct won't touch Embedding with a barge pole (and I can't blame them), so I had to include a solution that takes the output and does the embedding/flattening of the hierarchy quite manually after the parsing.  This does however seem to work, negates the need for the EmbeddedSwitch (which returned different results from just Switch) and I believe the sections, globals and TPI data all works.

I haven't test much else, but do please shout if there's additional issues, I'm happy to help try to get this up to speed with the latest construct (since it sounds as though it's going unsupported and therefore won't need converting again in the future).

I've also added .gitignore and a yapf style file (which reformatted a great deal of the code).  Hopefully that's not too problematic, and will keep the code in neater order if there are contributions in the future.